### PR TITLE
Registration and evaluation pipeline (with BIDS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ In the second part of the pipeline, these 3 files are used to compute some measu
 The second measurement is representative of the spinal cord overlap. To compute this value, the segmentation of the spinal cord should be obtained. This is done with the [`sct_deepseg_sc` feature](https://spinalcordtoolbox.com/user_section/command-line.html#sct-deepseg-sc) of the Spinal Cord Toolbox ([SCT](https://spinalcordtoolbox.com/)) software.  
 The spinal cord segmentations are saved and used to compute the volume overlap (Dice score) with the file `eval_reg_on_sc_seg.py`. The results are saved in the file `dice_score.csv` that summarises the results obtained for the different comparisons done.  
 
-Additionally, a Quality Control (QC) report is generated using [`sct_qc`](https://spinalcordtoolbox.com/user_section/command-line.html#sct-qc) from SCT allowing to control the spinal cord segmentations as well as the spinal cord registration. This report takes the form of a `.html` file and can be find at `qc/index.html`.
+Additionally, a Quality Control (QC) report is generated using [`sct_qc`](https://spinalcordtoolbox.com/user_section/command-line.html#sct-qc) from SCT allowing to control the spinal cord segmentations as well as the spinal cord registration. This report takes the form of a `.html` file and can be find at `qc/index.html` in your result folder.
 
 <img width="900" alt="Capture d’écran 2021-12-03 à 17 30 01" src="https://user-images.githubusercontent.com/32447627/144681407-635ad819-be82-41de-acee-b573ab31aba5.png">
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ In the second part of the pipeline, these 3 files are used to compute some measu
 The second measurement is representative of the spinal cord overlap. To compute this value, the segmentation of the spinal cord should be obtained. This is done with the [`sct_deepseg_sc` feature](https://spinalcordtoolbox.com/user_section/command-line.html#sct-deepseg-sc) of the Spinal Cord Toolbox ([SCT](https://spinalcordtoolbox.com/)) software.  
 The spinal cord segmentations are saved and used to compute the volume overlap (Dice score) with the file `eval_reg_on_sc_seg.py`. The results are saved in the file `dice_score.csv` that summarises the results obtained for the different comparisons done.  
 
-Additionally, a Quality Control (QC) report is generated using [`sct_qc`](https://spinalcordtoolbox.com/user_section/command-line.html#sct-qc) from SCT allowing to control the spinal cord segmentations as well as the spinal cord registration. This report takes the form of a `.html` file and can be find at `qc/index.html` in your result folder.
+Additionally, a Quality Control (QC) report is generated using [`sct_qc`](https://spinalcordtoolbox.com/user_section/command-line.html#sct-qc) from SCT allowing to control the spinal cord segmentations as well as the spinal cord registration. This report takes the form of a `.html` file and can be found at `qc/index.html` in your result folder.
 
 <img width="900" alt="Capture d’écran 2021-12-03 à 17 30 01" src="https://user-images.githubusercontent.com/32447627/144681407-635ad819-be82-41de-acee-b573ab31aba5.png">
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,6 @@ In the project directory, if your BIDS dataset is in the same directory in the `
 sct_run_batch -jobs 1 -path-data bids_dataset -path-out res_registration -script pipeline_bids_register_evaluate.sh
 ```
 
-⚠️ To use this pipeline you should [install SCT](https://spinalcordtoolbox.com/user_section/installation.html) and have it active in your working environment when running the shell script.  
+⚠️ To use this pipeline you should [install SCT](https://spinalcordtoolbox.com/user_section/installation.html) and have it active in your working environment when running the shell script. The script has been tested with SCT version [5.4](https://github.com/spinalcordtoolbox/spinalcordtoolbox/releases/tag/5.4). 
 
 

--- a/README.md
+++ b/README.md
@@ -68,3 +68,27 @@ To generate a deformation field and deform a volume with it:
 ```
 python gen_apply_def_field.py --im-path data/t2.nii.gz
 ```
+
+## Registration & Evaluation pipeline
+
+A pipeline for T2w volume registration to T1w volume for each subject of any dataset following Brain Imaging Data Structure ([BIDS](https://bids.neuroimaging.io/)) convention is provided with the shell script `pipeline_bids_register_evaluate.sh`. 
+For each subject of the dataset, the T2w volume will be registered to the T1w volume using a registration model which name should be specified in the shell script and that should be located in the `model/` folder. This first part of the pipeline leads to the creation of 3 new files for each subject: `sub-xx_T1w_proc.nii.gz`, `sub-xx_T2w_proc.nii.gz` and `sub-xx_T2w_proc_reg_to_T1w.nii.gz`. It is done with the file `bids_registration.py`.  
+
+In the second part of the pipeline, these 3 files are used to compute some measurements and obtain a QC report in order to have a an idea of the registration performance. One measurement, the normalized Mutual Information is computed directly on the files obtained with the registration process (first part). It is done with the file `eval_reg_with_mi.py` and results in the file `nmi.csv` that summarises the results obtained for the different comparisons done. 
+
+The second measurement is representative of the spinal cord overlap. To compute this value, the segmentation of the spinal cord should be obtained. This is done with the [`sct_deepseg_sc` feature](https://spinalcordtoolbox.com/user_section/command-line.html#sct-deepseg-sc) of the Spinal Cord Toolbox ([SCT](https://spinalcordtoolbox.com/)) software.  
+The spinal cord segmentations are saved and used to compute the volume overlap (Dice score) with the file `eval_reg_on_sc_seg.py`. The results are saved in the file `dice_score.csv` that summarises the results obtained for the different comparisons done.  
+
+Additionally, a Quality Control (QC) report is generated using [`sct_qc`](https://spinalcordtoolbox.com/user_section/command-line.html#sct-qc) from SCT allowing to control the spinal cord segmentations as well as the spinal cord registration. This report takes the form of a `.html` file and can be find at `qc/index.html`.
+
+<img width="900" alt="Capture d’écran 2021-12-03 à 17 30 01" src="https://user-images.githubusercontent.com/32447627/144681407-635ad819-be82-41de-acee-b573ab31aba5.png">
+
+To run the shell script, [`sct_run_batch`](https://spinalcordtoolbox.com/user_section/command-line.html#sct-run-batch) from SCT is used.  
+In the project directory, if your BIDS dataset is in the same directory in the `bids_dataset` folder, you can execute the following command to run the registration and evaluation pipeline:
+```
+sct_run_batch -jobs 1 -path-data bids_dataset -path-out res_registration -script pipeline_bids_register_evaluate.sh
+```
+
+⚠️ To use this pipeline you should [install SCT](https://spinalcordtoolbox.com/user_section/installation.html) and have it active in your working environment when running the shell script.  
+
+

--- a/bids_registration.py
+++ b/bids_registration.py
@@ -29,8 +29,9 @@ def preprocess(im_nii, mov_im_nii, in_shape=(160, 160, 192)):
     scaled_img = nib.load('scaled_image.nii')
 
     # sampling strategy: https://www.kaggle.com/mechaman/resizing-reshaping-and-resampling-nifti-files
+    # the brain images are mapped to the specified target shape at 1 mm isotropic resolution
     target_shape = np.array(in_shape)
-    new_resolution = [im_shape[0]/target_shape[0], im_shape[1]/target_shape[1], im_shape[2]/target_shape[2]]
+    new_resolution = [1, 1, 1]
     new_affine = np.zeros((4, 4))
     new_affine[:3, :3] = np.diag(new_resolution)
     # putting point 0,0,0 in the middle of the new volume - this could be refined in the future

--- a/bids_registration.py
+++ b/bids_registration.py
@@ -1,0 +1,116 @@
+"""
+File to load a trained registration model and register two images together.
+It includes a preprocessing step to transform the volumes to the dimensions required by the model.
+The images will be processed (and saved as im_name_proc) to be used in the registration model and then registered.
+The registered image is saved (as im_name_proc_reg_to_CONTRAST). The deformation field is also saved.
+This file can be used in a batch script to register the data of interest from all subjects in a dataset organized
+according to the Brain Imaging Data Structure (BIDS) convention.
+The contrast of the fixed image can be specified as argument for the files naming
+"""
+
+import os
+import argparse
+
+import numpy as np
+import nibabel as nib
+import voxelmorph as vxm
+
+from nilearn.image import resample_img
+
+def preprocess(im_nii, mov_im_nii, in_shape=(160, 160, 192)):
+    ''' Resize and normalize image. '''
+
+    rescale_factor = 1 / (np.max(im_nii.get_fdata()) - np.min(im_nii.get_fdata()))
+    im_shape = im_nii.shape
+
+    # Scale the data between 0 and 1
+    im_nii.header.set_slope_inter(rescale_factor, - np.min(im_nii.get_fdata()))
+    nib.save(im_nii, 'scaled_image.nii')
+    scaled_img = nib.load('scaled_image.nii')
+
+    # sampling strategy: https://www.kaggle.com/mechaman/resizing-reshaping-and-resampling-nifti-files
+    target_shape = np.array(in_shape)
+    new_resolution = [im_shape[0]/target_shape[0], im_shape[1]/target_shape[1], im_shape[2]/target_shape[2]]
+    new_affine = np.zeros((4, 4))
+    new_affine[:3, :3] = np.diag(new_resolution)
+    # putting point 0,0,0 in the middle of the new volume - this could be refined in the future
+    new_affine[:3, 3] = target_shape*new_resolution/2.*-1
+    new_affine[3, 3] = 1.
+
+    # Resample the 3d image to be in the dimension expected by the registration model
+    resampled_nii = resample_img(scaled_img, target_affine=new_affine,
+                                 target_shape=target_shape, interpolation='continuous')
+    os.remove('scaled_image.nii')
+
+    # Moving image
+    rescale_factor = 1 / (np.max(mov_im_nii.get_fdata()) - np.min(mov_im_nii.get_fdata()))
+
+    # Scale the data between 0 and 1
+    mov_im_nii.header.set_slope_inter(rescale_factor, - np.min(mov_im_nii.get_fdata()))
+    nib.save(mov_im_nii, 'scaled_image_mov.nii')
+    scaled_img_mov = nib.load('scaled_image_mov.nii')
+
+    # Resample the 3d image to be in the dimension expected by the registration model
+    mov_resampled_nii = resample_img(scaled_img_mov, target_affine=new_affine,
+                                     target_shape=target_shape, interpolation='continuous')
+    os.remove('scaled_image_mov.nii')
+
+    return resampled_nii, mov_resampled_nii
+
+
+def register(reg_model, fx_im_path, mov_im_path, fx_contrast='T1w'):
+    """
+    Preprocess the two images using the provided model
+    and register the moving image to the fixed one.
+    Save the warped image and the deformation field.
+    """
+
+    model_in_shape = reg_model.inputs[0].shape[1:-1]
+
+    fixed_nii = nib.load(f'{fx_im_path}.nii.gz')
+    moving_nii = nib.load(f'{mov_im_path}.nii.gz')
+
+    fixed, moving = preprocess(fixed_nii, moving_nii, model_in_shape)
+
+    nib.save(fixed, os.path.join(f'{fx_im_path}_proc.nii.gz'))
+    nib.save(moving, os.path.join(f'{mov_im_path}_proc.nii.gz'))
+
+    moved, warp = reg_model.predict([np.expand_dims(moving.get_fdata().squeeze(), axis=(0, -1)),
+                                     np.expand_dims(fixed.get_fdata().squeeze(), axis=(0, -1))])
+
+    moved = nib.Nifti1Image(moved[0, ..., 0], fixed.affine)
+    warp = nib.Nifti1Image(warp[0, ..., 0], fixed.affine)
+
+    nib.save(moved, os.path.join(f'{mov_im_path}_proc_reg_to_{fx_contrast}.nii.gz'))
+    nib.save(warp, os.path.join(f'{mov_im_path}_proc_field_to_{fx_contrast}.nii.gz'))
+
+
+def run_main(reg_model_path, fx_im_path, mov_im_path, fx_im_contrast='T1w'):
+    """
+    Load the registration model
+    Preprocess the fixed and moving images
+    Register
+    """
+    # Load the registration model
+    model = vxm.networks.VxmDense.load(reg_model_path, input_model=None)
+
+    register(model, fx_im_path, mov_im_path, fx_contrast=fx_im_contrast)
+
+
+if __name__ == "__main__":
+
+    # parse the commandline
+    parser = argparse.ArgumentParser()
+
+    # parameters to be specified by the user
+    parser.add_argument('--model-path', required=True, type=str, help='path to the registration model')
+
+    parser.add_argument('--fx-img-path', required=True, help='path to the fixed image')
+    parser.add_argument('--mov-img-path', required=True, help='path to the moving image')
+
+    parser.add_argument('--fx-img-contrast', required=False, default='T1w',
+                        help='contrast of the fixed image: one of {T1w, T2w, T2star}')
+
+    args = parser.parse_args()
+
+    run_main(args.model_path, args.fx_img_path, args.mov_img_path, args.fx_img_contrast)

--- a/bids_registration.py
+++ b/bids_registration.py
@@ -12,6 +12,7 @@ import os
 import argparse
 
 import numpy as np
+import tensorflow as tf
 import nibabel as nib
 import voxelmorph as vxm
 
@@ -112,6 +113,15 @@ if __name__ == "__main__":
     parser.add_argument('--fx-img-contrast', required=False, default='T1w',
                         help='contrast of the fixed image: one of {T1w, T2w, T2star}')
 
+    parser.add_argument('--one-cpu-tf', required=False, type=str, default='True',
+                        help='boolean to determine if the processes link to TF have access to one CPU (True) or all '
+                             'the CPUs (False) {\'0\',\'1\', \'False\',\'True\'}')
+
     args = parser.parse_args()
+
+    if eval(args.one_cpu_tf):
+        # set that TF can use only one CPU
+        session_conf = tf.compat.v1.ConfigProto(intra_op_parallelism_threads=1, inter_op_parallelism_threads=1)
+        sess = tf.compat.v1.Session(config=session_conf)
 
     run_main(args.model_path, args.fx_img_path, args.mov_img_path, args.fx_img_contrast)

--- a/bids_registration.py
+++ b/bids_registration.py
@@ -18,16 +18,14 @@ import voxelmorph as vxm
 
 from nilearn.image import resample_img
 
+
 def preprocess(im_nii, mov_im_nii, in_shape=(160, 160, 192)):
     ''' Resize and normalize image. '''
 
-    rescale_factor = 1 / (np.max(im_nii.get_fdata()) - np.min(im_nii.get_fdata()))
-    im_shape = im_nii.shape
-
     # Scale the data between 0 and 1
-    im_nii.header.set_slope_inter(rescale_factor, - np.min(im_nii.get_fdata()))
-    nib.save(im_nii, 'scaled_image.nii')
-    scaled_img = nib.load('scaled_image.nii')
+    img = im_nii.get_fdata()
+    scaled_img = (img - np.min(img)) / (np.max(img) - np.min(img))
+    scaled_nii = nib.Nifti1Image(scaled_img, im_nii.affine)
 
     # sampling strategy: https://www.kaggle.com/mechaman/resizing-reshaping-and-resampling-nifti-files
     # the brain images are mapped to the specified target shape at 1 mm isotropic resolution
@@ -40,22 +38,17 @@ def preprocess(im_nii, mov_im_nii, in_shape=(160, 160, 192)):
     new_affine[3, 3] = 1.
 
     # Resample the 3d image to be in the dimension expected by the registration model
-    resampled_nii = resample_img(scaled_img, target_affine=new_affine,
+    resampled_nii = resample_img(scaled_nii, target_affine=new_affine,
                                  target_shape=target_shape, interpolation='continuous')
-    os.remove('scaled_image.nii')
-
-    # Moving image
-    rescale_factor = 1 / (np.max(mov_im_nii.get_fdata()) - np.min(mov_im_nii.get_fdata()))
 
     # Scale the data between 0 and 1
-    mov_im_nii.header.set_slope_inter(rescale_factor, - np.min(mov_im_nii.get_fdata()))
-    nib.save(mov_im_nii, 'scaled_image_mov.nii')
-    scaled_img_mov = nib.load('scaled_image_mov.nii')
+    mov_img = mov_im_nii.get_fdata()
+    scaled_mov_img = (mov_img - np.min(mov_img)) / (np.max(mov_img) - np.min(mov_img))
+    scaled_nii = nib.Nifti1Image(scaled_mov_img, mov_im_nii.affine)
 
     # Resample the 3d image to be in the dimension expected by the registration model
-    mov_resampled_nii = resample_img(scaled_img_mov, target_affine=new_affine,
+    mov_resampled_nii = resample_img(scaled_nii, target_affine=new_affine,
                                      target_shape=target_shape, interpolation='continuous')
-    os.remove('scaled_image_mov.nii')
 
     return resampled_nii, mov_resampled_nii
 

--- a/eval_reg_on_sc_seg.py
+++ b/eval_reg_on_sc_seg.py
@@ -1,0 +1,94 @@
+"""
+File taking three segmentation images (paths) as input and computing the dice metric to evaluate
+how well the images are registered.
+The dice scores are saved in a csv file.
+"""
+
+import argparse
+import os
+
+import numpy as np
+import nibabel as nib
+import csv
+import datetime
+
+
+if __name__ == "__main__":
+
+    # -------------------------------------------------------------------------------------------------------- #
+    # ----                                       PARSER ARGUMENTS                                         ---- #
+    # -------------------------------------------------------------------------------------------------------- #
+
+    # parse command line
+    p = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,
+                                description=f'Evaluate the registration of two volumes')
+
+    # path parameters
+    p.add_argument('--fx-seg-path', required=True, help='path to the spinal cord segmentation of the fixed image')
+    p.add_argument('--moving-seg-path', required=True, help='path to the spinal cord segmentation of the moving image')
+    p.add_argument('--warped-seg-path', required=True, help='path to the spinal cord segmentation of the moved image')
+
+    p.add_argument('--sub-id', required=True, help='id of the subject')
+
+    p.add_argument('--out-file', required=False, default='dice_score.csv',
+                   help='path to csv summarizing the dice scores')
+    p.add_argument('--append', type=int, required=False, default=1, choices=[0, 1],
+                   help="Append results as a new line in the output csv file instead of overwriting it.")
+
+    arg = p.parse_args()
+
+    # -------------------------------------------------------------------------------------------------------- #
+    # ----                                      LOADING THE VOLUMES                                       ---- #
+    # -------------------------------------------------------------------------------------------------------- #
+
+    if len(arg.fx_seg_path.split('.')) > 1:
+        fx_im = nib.load(arg.fx_seg_path)
+    else:
+        fx_im = nib.load(f'{arg.fx_seg_path}.nii.gz')
+
+    if len(arg.moving_seg_path.split('.')) > 1:
+        moving_im = nib.load(arg.moving_seg_path)
+    else:
+        moving_im = nib.load(f'{arg.moving_seg_path}.nii.gz')
+
+    if len(arg.warped_seg_path.split('.')) > 1:
+        moved_im = nib.load(arg.warped_seg_path)
+    else:
+        moved_im = nib.load(f'{arg.warped_seg_path}.nii.gz')
+
+    fx_im_val = fx_im.get_fdata()
+    moving_im_val = moving_im.get_fdata()
+    moved_im_val = moved_im.get_fdata()
+
+    # -------------------------------------------------------------------------------------------------------- #
+    # ----                   COMPUTE THE DICE SCORE REPRESENTING SC SEGMENTATION OVERLAP                  ---- #
+    # -------------------------------------------------------------------------------------------------------- #
+
+    dice_fx_moving = np.sum(moving_im_val[fx_im_val == 1]) * 2.0 / (np.sum(moving_im_val) + np.sum(fx_im_val))
+    dice_fx_moved = np.sum(moved_im_val[fx_im_val == 1]) * 2.0 / (np.sum(moved_im_val) + np.sum(fx_im_val))
+    dice_moving_moved = np.sum(moved_im_val[moving_im_val == 1]) * 2.0 / (np.sum(moved_im_val) + np.sum(moving_im_val))
+
+    perc_dice_improvement = 100 * (dice_fx_moved - dice_fx_moving)/dice_fx_moving
+
+    res_summary = dict()
+    res_summary['subject'] = arg.sub_id
+    res_summary['dice_before_registration'] = dice_fx_moving
+    res_summary['dice_after_registration'] = dice_fx_moved
+    res_summary['dice_between_moving_and_moved_images'] = dice_moving_moved
+    res_summary['perc_dice_improvement_with_registration'] = np.round(perc_dice_improvement, 2)
+
+    # write header (only if append=False)
+    if not arg.append or not os.path.isfile(arg.out_file):
+        with open(arg.out_file, 'w') as csvfile:
+            header = ['Timestamp', 'Subject', 'Dice_before_registration', 'Dice_after_registration', 'Dice_between_moving_and_moved_images', 'Percentage_dice_improvement_registration']
+            writer = csv.DictWriter(csvfile, fieldnames=header)
+            writer.writeheader()
+
+    # populate data
+    with open(arg.out_file, 'a') as csvfile:
+        spamwriter = csv.writer(csvfile, delimiter=',')
+        line = list()
+        line.append(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))  # Timestamp
+        for val in res_summary.keys():
+            line.append(str(res_summary[val]))
+        spamwriter.writerow(line)

--- a/eval_reg_with_mi.py
+++ b/eval_reg_with_mi.py
@@ -41,6 +41,7 @@ def normalized_mutual_information(image0, image1, bins=100):
     Compute the normalized mutual information (NMI).
     It ranges from 1 (perfectly uncorrelated image values) to 2 (perfectly correlated image values,
     whether positively or negatively).
+    This implementation is based on Studholme and colleagues work [1].
     Parameters
     ----------
     image0, image1 : ndarray
@@ -54,14 +55,17 @@ def normalized_mutual_information(image0, image1, bins=100):
         The normalized mutual information between the two arrays, computed at
         the granularity given by ``bins``. Higher NMI implies more similar
         input images.
+    Reference
+    ---------
+    [1] C. Studholme, D.L.G. Hill, & D.J. Hawkes (1999).
+        An overlap invariant entropy measure of 3D medical image alignment.
+        Pattern Recognition 32(1):71-86 :DOI:`10.1016/S0031-3203(98)00091-0`
     """
 
     hist, bin_edges = np.histogramdd(
         [np.reshape(image0, -1), np.reshape(image1, -1)],
         bins=bins
     )
-
-    # hist = hist[1:, 1:]
 
     H0 = entropy(np.sum(hist, axis=0))
     H1 = entropy(np.sum(hist, axis=1))

--- a/eval_reg_with_mi.py
+++ b/eval_reg_with_mi.py
@@ -1,0 +1,159 @@
+"""
+File taking three images (fixed, moving, moved) and computing the (normalized) Mutual Information (MI) between these
+images to evaluate the registration performance.
+"""
+
+import argparse
+import os
+
+import numpy as np
+import nibabel as nib
+import csv
+import datetime
+from scipy.stats import entropy
+
+
+def detect_zero_padding(im):
+    """
+    Return the x_min, y_min, ... of the non zero-padded area
+    """
+    xy_plan = np.sum(im, axis=2)
+    yz_plan = np.sum(im, axis=0)
+
+    x_plan = np.sum(xy_plan, axis=1)
+    x_min = np.argwhere(x_plan > 0)[0][0]
+    x_max = np.argwhere(x_plan > 0)[-1][0]
+
+    y_plan = np.sum(yz_plan, axis=1)
+    y_min = np.argwhere(y_plan > 0)[0][0]
+    y_max = np.argwhere(y_plan > 0)[-1][0]
+
+    z_plan = np.sum(yz_plan, axis=0)
+    z_min = np.argwhere(z_plan > 0)[0][0]
+    z_max = np.argwhere(z_plan > 0)[-1][0]
+
+    return x_min, y_min, z_min, x_max, y_max, z_max
+
+
+def normalized_mutual_information(image0, image1, bins=100):
+    r"""
+    Function from scikit-image github
+    Compute the normalized mutual information (NMI).
+    It ranges from 1 (perfectly uncorrelated image values) to 2 (perfectly correlated image values,
+    whether positively or negatively).
+    Parameters
+    ----------
+    image0, image1 : ndarray
+        Images to be compared. The two input images must have the same number
+        of dimensions.
+    bins : int or sequence of int, optional
+        The number of bins along each axis of the joint histogram.
+    Returns
+    -------
+    nmi : float
+        The normalized mutual information between the two arrays, computed at
+        the granularity given by ``bins``. Higher NMI implies more similar
+        input images.
+    """
+
+    hist, bin_edges = np.histogramdd(
+        [np.reshape(image0, -1), np.reshape(image1, -1)],
+        bins=bins
+    )
+
+    # hist = hist[1:, 1:]
+
+    H0 = entropy(np.sum(hist, axis=0))
+    H1 = entropy(np.sum(hist, axis=1))
+    H01 = entropy(np.reshape(hist, -1))
+
+    return (H0 + H1) / H01
+
+
+if __name__ == "__main__":
+
+    # -------------------------------------------------------------------------------------------------------- #
+    # ----                                       PARSER ARGUMENTS                                         ---- #
+    # -------------------------------------------------------------------------------------------------------- #
+
+    # parse command line
+    p = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,
+                                description=f'Evaluate the registration of two volumes')
+
+    # path parameters
+    p.add_argument('--fx-im-path', required=True, help='path to the fixed image')
+    p.add_argument('--moving-im-path', required=True, help='path to the moving image')
+    p.add_argument('--warped-im-path', required=True, help='path to the moved image')
+
+    p.add_argument('--sub-id', required=True, help='id of the subject')
+
+    p.add_argument('--out-file', required=False, default='nmi.csv',
+                   help='path to csv summarizing the mutual information results')
+    p.add_argument('--append', type=int, required=False, default=1, choices=[0, 1],
+                   help="Append results as a new line in the output csv file instead of overwriting it.")
+
+    arg = p.parse_args()
+
+    # -------------------------------------------------------------------------------------------------------- #
+    # ----                                      LOADING THE VOLUMES                                       ---- #
+    # -------------------------------------------------------------------------------------------------------- #
+
+    if len(arg.fx_im_path.split('.')) > 1:
+        fx_im = nib.load(arg.fx_im_path)
+    else:
+        fx_im = nib.load(f'{arg.fx_im_path}.nii.gz')
+
+    if len(arg.moving_im_path.split('.')) > 1:
+        moving_im = nib.load(arg.moving_im_path)
+    else:
+        moving_im = nib.load(f'{arg.moving_im_path}.nii.gz')
+
+    if len(arg.warped_im_path.split('.')) > 1:
+        moved_im = nib.load(arg.warped_im_path)
+    else:
+        moved_im = nib.load(f'{arg.warped_im_path}.nii.gz')
+
+    fx_im_val = fx_im.get_fdata()
+    moving_im_val = moving_im.get_fdata()
+    moved_im_val = moved_im.get_fdata()
+
+    x_min, y_min, z_min, x_max, y_max, z_max = detect_zero_padding(moving_im_val)
+
+    # Resize the images to remove the zero-padded part so it's not considered in the NMI computation
+    fx_im_val = fx_im_val[x_min:x_max+1, y_min:y_max+1, z_min:z_max+1]
+    moving_im_val = moving_im_val[x_min:x_max+1, y_min:y_max+1, z_min:z_max+1]
+    moved_im_val = moved_im_val[x_min:x_max+1, y_min:y_max+1, z_min:z_max+1]
+
+    # -------------------------------------------------------------------------------------------------------- #
+    # ----                                       COMPUTE THE NMI                                          ---- #
+    # -------------------------------------------------------------------------------------------------------- #
+
+    nmi_fx_moving = normalized_mutual_information(fx_im_val, moving_im_val)
+    nmi_fx_moved = normalized_mutual_information(fx_im_val, moved_im_val)
+    nmi_moving_moved = normalized_mutual_information(moving_im_val, moved_im_val)
+
+    perc_nmi_improvement = 100 * (nmi_fx_moved - nmi_fx_moving)/nmi_fx_moving
+
+    res_summary = dict()
+    res_summary['subject'] = arg.sub_id
+    res_summary['nmi_before_registration'] = nmi_fx_moving
+    res_summary['nmi_after_registration'] = nmi_fx_moved
+    res_summary['nmi_between_moving_and_moved_images'] = nmi_moving_moved
+    res_summary['perc_nmi_improvement_with_registration'] = np.round(perc_nmi_improvement, 2)
+
+    # write header (only if append=False)
+    if not arg.append or not os.path.isfile(arg.out_file):
+        with open(arg.out_file, 'w') as csvfile:
+            header = ['Timestamp', 'Subject', 'NMI_before_registration', 'NMI_after_registration', 'NMI_between_moving_and_moved_images', 'Percentage_nmi_improvement_registration']
+            writer = csv.DictWriter(csvfile, fieldnames=header)
+            writer.writeheader()
+
+    # populate data
+    with open(arg.out_file, 'a') as csvfile:
+        spamwriter = csv.writer(csvfile, delimiter=',')
+        line = list()
+        line.append(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))  # Timestamp
+        for val in res_summary.keys():
+            line.append(str(res_summary[val]))
+        spamwriter.writerow(line)
+

--- a/pipeline_bids_register_evaluate.sh
+++ b/pipeline_bids_register_evaluate.sh
@@ -74,7 +74,7 @@ CONDA_BASE=$(conda info --base)
 source $CONDA_BASE/etc/profile.d/conda.sh
 conda activate smenv
 # Perform processing and registration
-python $PATH_SCRIPT/bids_registration.py --model-path $PATH_SCRIPT/model/$REGISTRATION_MODEL --fx-img-path $file_t1_before_proc --mov-img-path $file_t2_before_proc --fx-img-contrast T1w
+python $PATH_SCRIPT/bids_registration.py --model-path $PATH_SCRIPT/model/$REGISTRATION_MODEL --fx-img-path $file_t1_before_proc --mov-img-path $file_t2_before_proc --fx-img-contrast T1w --one-cpu-tf True
 conda deactivate
 
 file_t1="${SES}_T1w_proc"

--- a/pipeline_bids_register_evaluate.sh
+++ b/pipeline_bids_register_evaluate.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+#
+# Register T2w volumes to T1w volumes and evaluate the registration by computing the volume overlap of the spinal cord
+# segmentations of the volumes involved in the process and the mutual information between these volumes as well
+#
+# Usage:
+# sct_run_batch -jobs 1 -path-data bids_dataset -path-out res_registration -script pipeline_bids_register_evaluate.sh
+#
+#
+# Author: Evan Béal
+
+set -x
+# Immediately exit if error
+set -e -o pipefail
+
+# Exit if user presses CTRL+C (Linux, OSX)
+trap "echo Caught Keyboard Interrupt within script. Exiting now.; exit" INT
+
+# Retrieve input params
+SUBJECT=$1
+
+# Save script path
+PATH_SCRIPT=$PWD
+
+# get starting time:
+start=`date +%s`
+
+# FUNCTIONS
+# ==============================================================================
+
+# Perform segmentation.
+segment(){
+  local file="$1"
+  local contrast="$2"
+  folder_contrast="anat"
+
+  echo "Proceeding with automatic segmentation"
+  # Segment spinal cord
+  sct_deepseg_sc -i ${file}.nii.gz -c $contrast -qc ${PATH_QC} -qc-subject ${SUBJECT}
+}
+
+compute_metrics(){
+  local file="$1"
+  local out="$2"
+
+  echo "Compute metrics on segmentation"
+  # Compute metrics
+  sct_process_segmentation -i ${file}.nii.gz -o ${out}.csv -perslice 0 -angle-corr 1 -append 1
+
+}
+
+# SCRIPT STARTS HERE
+# ==============================================================================
+# Display useful info for the log, such as SCT version, RAM and CPU cores available
+sct_check_dependencies -short
+
+SUBJECT_ID=$(dirname "$SUBJECT")
+SES=$(basename "$SUBJECT")
+# Go to folder where data will be copied and processed
+cd ${PATH_DATA_PROCESSED}
+# Copy source images
+mkdir -p ${SUBJECT}
+rsync -avzh $PATH_DATA/$SUBJECT/ ${SUBJECT}
+# Go to anat folder where all structural data are located
+echo $PWD
+cd ${SUBJECT}/anat/
+
+file_t1_before_proc="${SES}_T1w"
+file_t2_before_proc="${SES}_T2w"
+
+REGISTRATION_MODEL="registration_model.h5"
+
+CONDA_BASE=$(conda info --base)
+source $CONDA_BASE/etc/profile.d/conda.sh
+conda activate smenv
+# Perform processing and registration
+python $PATH_SCRIPT/bids_registration.py --model-path $PATH_SCRIPT/model/$REGISTRATION_MODEL --fx-img-path $file_t1_before_proc --mov-img-path $file_t2_before_proc --fx-img-contrast T1w
+conda deactivate
+
+file_t1="${SES}_T1w_proc"
+file_t2="${SES}_T2w_proc"
+file_t2_reg="${SES}_T2w_proc_reg_to_T1w"
+
+# Segment spinal cord
+segment $file_t1 "t1"
+# file_t1_seg=$FILESEG
+
+segment $file_t2 "t2"
+# file_t2_seg=$FILESEG
+
+segment $file_t2_reg "t2"
+# file_t2_reg_seg=$FILESEG
+
+file_t1_seg="${SES}_T1w_proc_seg"
+file_t2_seg="${SES}_T2w_proc_seg"
+file_t2_reg_seg="${SES}_T2w_proc_reg_to_T1w_seg"
+
+# Compute Dice score of spinal cord segmentation overlap before and after registration
+# conda activate smenv
+# Compute Dice score and save the results in a csv file
+python $PATH_SCRIPT/eval_reg_on_sc_seg.py --fx-seg-path $file_t1_seg --moving-seg-path $file_t2_seg --warped-seg-path $file_t2_reg_seg --sub-id ${SES} --out-file $PATH_DATA_PROCESSED/dice_score.csv --append 1
+python $PATH_SCRIPT/eval_reg_with_mi.py --fx-im-path $file_t1_seg --moving-im-path $file_t2_seg --warped-im-path $file_t2_reg_seg --sub-id ${SES} --out-file $PATH_DATA_PROCESSED/nmi.csv --append 1
+# conda deactivate
+
+# Compute metrics
+compute_metrics "$file_t1_seg" "$PATH_DATA_PROCESSED/t1_seg"
+compute_metrics "$file_t2_seg" "$PATH_DATA_PROCESSED/t2_seg"
+compute_metrics "$file_t2_reg_seg" "$PATH_DATA_PROCESSED/t2_reg_seg"
+# sct_process_segmentation -i ${file_t1_seg}.nii.gz -o t1_seg.csv -perslice 1 -angle-corr 1 -append 1
+# sct_process_segmentation -i ${file_t2_seg}.nii.gz -o t2_seg.csv -perslice 1 -angle-corr 1 -append 1
+# sct_process_segmentation -i ${file_t2_reg_seg}.nii.gz -o t2_reg_seg.csv -perslice 1 -angle-corr 1 -append 1
+
+# Generate QC report to assess segmentation
+# sct_qc -i ${file_t1}.nii.gz -s ${file_t1_seg}.nii.gz -p sct_deepseg_sc -qc ${PATH_QC} -qc-subject ${SUBJECT}
+# sct_qc -i ${file_t2}.nii.gz -s ${file_t2_seg}.nii.gz -p sct_deepseg_sc -qc ${PATH_QC} -qc-subject ${SUBJECT}
+# sct_qc -i ${file_t2_reg}.nii.gz -s ${file_t2_reg_seg}.nii.gz -p sct_deepseg_sc -qc ${PATH_QC} -qc-subject ${SUBJECT}
+
+# Generate QC report to assess registration
+# sct_qc -i ${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${file_t1}.nii.gz -s ${file_t1_seg}.nii.gz -d ${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${file_t2}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
+sct_qc -i ${file_t1}.nii.gz -s ${file_t1_seg}.nii.gz -d ${file_t2}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
+sct_qc -i ${file_t1}.nii.gz -s ${file_t1_seg}.nii.gz -d ${file_t2_reg}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
+sct_qc -i ${file_t2}.nii.gz -s ${file_t2_seg}.nii.gz -d ${file_t2_reg}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
+
+# Verify presence of output files and write log file if error
+# ------------------------------------------------------------------------------
+FILES_TO_CHECK=(
+  "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T1w_proc.nii.gz"
+  "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T2w_proc.nii.gz"
+  "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T2w_proc_reg_to_T1w.nii.gz"
+  "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T1w_proc_seg.nii.gz"
+  "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T2w_proc_seg.nii.gz"
+  "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T2w_proc_reg_to_T1w_seg.nii.gz"
+)
+pwd
+for file in ${FILES_TO_CHECK[@]}; do
+  if [[ ! -e $file ]]; then
+    echo "${file} does not exist" >> $PATH_LOG/_error_check_output_files.log
+  fi
+done
+
+# Display useful info for the log
+end=`date +%s`
+runtime=$((end-start))
+echo
+echo "~~~"
+echo "SCT version: `sct_version`"
+echo "Ran on:      `uname -nsr`"
+echo "Duration:    $(($runtime / 3600))hrs $((($runtime / 60) % 60))min $(($runtime % 60))sec"
+echo "~~~"

--- a/pipeline_bids_register_evaluate.sh
+++ b/pipeline_bids_register_evaluate.sh
@@ -90,9 +90,12 @@ file_t1_seg="${SES}_T1w_proc_seg"
 file_t2_seg="${SES}_T2w_proc_seg"
 file_t2_reg_seg="${SES}_T2w_proc_reg_to_T1w_seg"
 
+conda activate smenv
 # Compute Dice score of SC segmentation overlap before and after registration and save the results in a csv file
 python $PATH_SCRIPT/eval_reg_on_sc_seg.py --fx-seg-path $file_t1_seg --moving-seg-path $file_t2_seg --warped-seg-path $file_t2_reg_seg --sub-id ${SES} --out-file $PATH_DATA_PROCESSED/dice_score.csv --append 1
+# Compute the normalized Mutual Information and save the results in a csv file
 python $PATH_SCRIPT/eval_reg_with_mi.py --fx-im-path $file_t1_seg --moving-im-path $file_t2_seg --warped-im-path $file_t2_reg_seg --sub-id ${SES} --out-file $PATH_DATA_PROCESSED/nmi.csv --append 1
+conda deactivate
 
 # Compute metrics
 compute_metrics "$file_t1_seg" "$PATH_DATA_PROCESSED/t1_seg"

--- a/pipeline_bids_register_evaluate.sh
+++ b/pipeline_bids_register_evaluate.sh
@@ -83,40 +83,23 @@ file_t2_reg="${SES}_T2w_proc_reg_to_T1w"
 
 # Segment spinal cord
 segment $file_t1 "t1"
-# file_t1_seg=$FILESEG
-
 segment $file_t2 "t2"
-# file_t2_seg=$FILESEG
-
 segment $file_t2_reg "t2"
-# file_t2_reg_seg=$FILESEG
 
 file_t1_seg="${SES}_T1w_proc_seg"
 file_t2_seg="${SES}_T2w_proc_seg"
 file_t2_reg_seg="${SES}_T2w_proc_reg_to_T1w_seg"
 
-# Compute Dice score of spinal cord segmentation overlap before and after registration
-# conda activate smenv
-# Compute Dice score and save the results in a csv file
+# Compute Dice score of SC segmentation overlap before and after registration and save the results in a csv file
 python $PATH_SCRIPT/eval_reg_on_sc_seg.py --fx-seg-path $file_t1_seg --moving-seg-path $file_t2_seg --warped-seg-path $file_t2_reg_seg --sub-id ${SES} --out-file $PATH_DATA_PROCESSED/dice_score.csv --append 1
 python $PATH_SCRIPT/eval_reg_with_mi.py --fx-im-path $file_t1_seg --moving-im-path $file_t2_seg --warped-im-path $file_t2_reg_seg --sub-id ${SES} --out-file $PATH_DATA_PROCESSED/nmi.csv --append 1
-# conda deactivate
 
 # Compute metrics
 compute_metrics "$file_t1_seg" "$PATH_DATA_PROCESSED/t1_seg"
 compute_metrics "$file_t2_seg" "$PATH_DATA_PROCESSED/t2_seg"
 compute_metrics "$file_t2_reg_seg" "$PATH_DATA_PROCESSED/t2_reg_seg"
-# sct_process_segmentation -i ${file_t1_seg}.nii.gz -o t1_seg.csv -perslice 1 -angle-corr 1 -append 1
-# sct_process_segmentation -i ${file_t2_seg}.nii.gz -o t2_seg.csv -perslice 1 -angle-corr 1 -append 1
-# sct_process_segmentation -i ${file_t2_reg_seg}.nii.gz -o t2_reg_seg.csv -perslice 1 -angle-corr 1 -append 1
-
-# Generate QC report to assess segmentation
-# sct_qc -i ${file_t1}.nii.gz -s ${file_t1_seg}.nii.gz -p sct_deepseg_sc -qc ${PATH_QC} -qc-subject ${SUBJECT}
-# sct_qc -i ${file_t2}.nii.gz -s ${file_t2_seg}.nii.gz -p sct_deepseg_sc -qc ${PATH_QC} -qc-subject ${SUBJECT}
-# sct_qc -i ${file_t2_reg}.nii.gz -s ${file_t2_reg_seg}.nii.gz -p sct_deepseg_sc -qc ${PATH_QC} -qc-subject ${SUBJECT}
 
 # Generate QC report to assess registration
-# sct_qc -i ${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${file_t1}.nii.gz -s ${file_t1_seg}.nii.gz -d ${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${file_t2}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
 sct_qc -i ${file_t1}.nii.gz -s ${file_t1_seg}.nii.gz -d ${file_t2}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
 sct_qc -i ${file_t1}.nii.gz -s ${file_t1_seg}.nii.gz -d ${file_t2_reg}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
 sct_qc -i ${file_t2}.nii.gz -s ${file_t2_seg}.nii.gz -d ${file_t2_reg}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}


### PR DESCRIPTION

## Registration & Evaluation pipeline

A pipeline for T2w volume registration to T1w volume for each subject of any dataset following Brain Imaging Data Structure ([BIDS](https://bids.neuroimaging.io/)) convention is provided with the shell script `pipeline_bids_register_evaluate.sh`. 
For each subject of the dataset, the T2w volume will be registered to the T1w volume using a registration model which name should be specified in the shell script and that should be located in the `model/` folder. This first part of the pipeline leads to the creation of 3 new files for each subject: `sub-xx_T1w_proc.nii.gz`, `sub-xx_T2w_proc.nii.gz` and `sub-xx_T2w_proc_reg_to_T1w.nii.gz`. It is done with the file `bids_registration.py`.  

In the second part of the pipeline, these 3 files are used to compute some measurements and obtain a QC report in order to have a an idea of the registration performance. One measurement, the normalized Mutual Information is computed directly on the files obtained with the registration process (first part). It is done with the file `eval_reg_with_mi.py` and results in the file `nmi.csv` that summarises the results obtained for the different comparisons done. 

The second measurement is representative of the spinal cord overlap. To compute this value, the segmentation of the spinal cord should be obtained. This is done with the [`sct_deepseg_sc` feature](https://spinalcordtoolbox.com/user_section/command-line.html#sct-deepseg-sc) of the Spinal Cord Toolbox ([SCT](https://spinalcordtoolbox.com/)) software.  
The spinal cord segmentations are saved and used to compute the volume overlap (Dice score) with the file `eval_reg_on_sc_seg.py`. The results are saved in the file `dice_score.csv` that summarises the results obtained for the different comparisons done.  

Additionally, a Quality Control (QC) report is generated using [`sct_qc`](https://spinalcordtoolbox.com/user_section/command-line.html#sct-qc) from SCT allowing to control the spinal cord segmentations as well as the spinal cord registration. This report takes the form of a `.html` file and can be find at `qc/index.html` in your result folder.

<img width="900" alt="Capture d’écran 2021-12-03 à 17 30 01" src="https://user-images.githubusercontent.com/32447627/144681407-635ad819-be82-41de-acee-b573ab31aba5.png">

To run the shell script, [`sct_run_batch`](https://spinalcordtoolbox.com/user_section/command-line.html#sct-run-batch) from SCT is used.  
In the project directory, if your BIDS dataset is in the same directory in the `bids_dataset` folder, you can execute the following command to run the registration and evaluation pipeline:
```
sct_run_batch -jobs 1 -path-data bids_dataset -path-out res_registration -script pipeline_bids_register_evaluate.sh
```

⚠️ To use this pipeline you should [install SCT](https://spinalcordtoolbox.com/user_section/installation.html) and have it active in your working environment when running the shell script. 