### PR TITLE
Optional affine registration step in registration and evaluation pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,7 @@ The spinal cord segmentations are saved and used to compute the volume overlap (
 
 Additionally, a Quality Control (QC) report is generated using [`sct_qc`](https://spinalcordtoolbox.com/user_section/command-line.html#sct-qc) from SCT allowing to control the spinal cord segmentations as well as the spinal cord registration. This report takes the form of a `.html` file and can be found at `qc/index.html` in your result folder.
 
-If the registration result obtained for a certain subject is not as high as desired (based on the Dice score of the spinal cord segmentations), an affine (rigid) registration is done on the input volumes before performing once again the deformable registration with the registration model specified in the shell script. The new results will be assessed with the second part of the pipeline and only these new results will be saved in the different files.
-Whether to enter this path of the pipeline or not is monitored by the Dice score obtained on the spinal cord segmentations and the limit fixed in the bash script with the parameter `MIN_SC_DICE_EXPECTED_PERC`. This latter can be set to 0 to avoid using the affine registration on any subjects.
-The addition of affine registration in the pipeline is thus optional and can be used as desired by the user to optimize the trade-off between additional computation time and improved registration results for subjects with volumes that are initially in different affine spaces.
-
-The affine registration step is done with [`sct_register_multimodal`](https://spinalcordtoolbox.com/user_section/command-line.html#sct-register-multimodal) from the [Spinal Cord Toolbox](https://spinalcordtoolbox.com/index.html) and using the centermass algorithm, which is a slice wise center of mass alignment done on the spinal cord segmentations (computed on the original input volumes).
-
-<img width="1020" alt="Capture d’écran 2021-12-22 à 16 53 15" src="https://user-images.githubusercontent.com/32447627/147159446-208a8b3a-04b6-4143-83fc-8a41464e960e.png">
+<img width="900" alt="Capture d’écran 2021-12-03 à 17 30 01" src="https://user-images.githubusercontent.com/32447627/144681407-635ad819-be82-41de-acee-b573ab31aba5.png">
 
 The files obtained during the process (segmentation, processed volumes or deformation fields) are organised into different folders. Two parameters at the beginning of the shell script are monitoring the organisation of the output files in the `anat` folder:
 - `DEBUGGING` 
@@ -102,6 +96,24 @@ The files obtained during the process (segmentation, processed volumes or deform
 In the project directory, if your BIDS dataset is in the same directory in the `bids_dataset` folder, you can execute the following command to run the registration and evaluation pipeline:
 ```
 sct_run_batch -jobs 1 -path-data bids_dataset -path-out res_registration -script pipeline_bids_register_evaluate.sh
+```
+
+⚠️ To use this pipeline you should [install SCT](https://spinalcordtoolbox.com/user_section/installation.html) and have it active in your working environment when running the shell script. The script has been tested with SCT version [5.4](https://github.com/spinalcordtoolbox/spinalcordtoolbox/releases/tag/5.4). 
+
+## Registration & Evaluation pipeline with optional affine registration step
+
+After having followed the same process as the one described in the above section, if the registration result obtained for a certain subject is not as high as desired (based on the Dice score of the spinal cord segmentations), an affine (rigid) registration is done on the input volumes before performing once again the deformable registration with the registration model specified in the shell script. The new results will be assessed with the second part of the pipeline and only these new results will be saved in the different files.
+Whether to enter this path of the pipeline or not is monitored by the Dice score obtained on the spinal cord segmentations and the limit fixed in the bash script with the parameter `MIN_SC_DICE_EXPECTED_PERC`. This latter can be set to 0 to avoid using the affine registration on any subjects.
+The addition of affine registration in the pipeline is thus optional and can be used as desired by the user to optimize the trade-off between additional computation time and improved registration results for subjects with volumes that are initially in different affine spaces.
+
+The affine registration step is done with [`sct_register_multimodal`](https://spinalcordtoolbox.com/user_section/command-line.html#sct-register-multimodal) from the [Spinal Cord Toolbox](https://spinalcordtoolbox.com/index.html) and using the centermass algorithm, which is a slice wise center of mass alignment done on the spinal cord segmentations (computed on the original input volumes).
+
+<img width="1020" alt="Capture d’écran 2021-12-22 à 16 53 15" src="https://user-images.githubusercontent.com/32447627/147159446-208a8b3a-04b6-4143-83fc-8a41464e960e.png">
+
+**To run the shell script**, [`sct_run_batch`](https://spinalcordtoolbox.com/user_section/command-line.html#sct-run-batch) from SCT is used.  
+In the project directory, if your BIDS dataset is in the same directory in the `bids_dataset` folder, you can execute the following command to run the registration and evaluation pipeline:
+```
+sct_run_batch -jobs 1 -path-data bids_dataset -path-out res_registration -script pipeline_bids_register_evaluate_opt_affine.sh
 ```
 
 ⚠️ To use this pipeline you should [install SCT](https://spinalcordtoolbox.com/user_section/installation.html) and have it active in your working environment when running the shell script. The script has been tested with SCT version [5.4](https://github.com/spinalcordtoolbox/spinalcordtoolbox/releases/tag/5.4). 

--- a/README.md
+++ b/README.md
@@ -82,14 +82,26 @@ The spinal cord segmentations are saved and used to compute the volume overlap (
 
 Additionally, a Quality Control (QC) report is generated using [`sct_qc`](https://spinalcordtoolbox.com/user_section/command-line.html#sct-qc) from SCT allowing to control the spinal cord segmentations as well as the spinal cord registration. This report takes the form of a `.html` file and can be found at `qc/index.html` in your result folder.
 
-<img width="900" alt="Capture d’écran 2021-12-03 à 17 30 01" src="https://user-images.githubusercontent.com/32447627/144681407-635ad819-be82-41de-acee-b573ab31aba5.png">
+If the registration result obtained for a certain subject is not as high as desired (based on the Dice score of the spinal cord segmentations), an affine (rigid) registration is done on the input volumes before performing once again the deformable registration with the registration model specified in the shell script. The new results will be assessed with the second part of the pipeline and only these new results will be saved in the different files.
+Whether to enter this path of the pipeline or not is monitored by the Dice score obtained on the spinal cord segmentations and the limit fixed in the bash script with the parameter `MIN_SC_DICE_EXPECTED_PERC`. This latter can be set to 0 to avoid using the affine registration on any subjects.
+The addition of affine registration in the pipeline is thus optional and can be used as desired by the user to optimize the trade-off between additional computation time and improved registration results for subjects with volumes that are initially in different affine spaces.
 
-To run the shell script, [`sct_run_batch`](https://spinalcordtoolbox.com/user_section/command-line.html#sct-run-batch) from SCT is used.  
+The affine registration step is done with [`sct_register_multimodal`](https://spinalcordtoolbox.com/user_section/command-line.html#sct-register-multimodal) from the [Spinal Cord Toolbox](https://spinalcordtoolbox.com/index.html) and using the centermass algorithm, which is a slice wise center of mass alignment done on the spinal cord segmentations (computed on the original input volumes).
+
+<img width="1020" alt="Capture d’écran 2021-12-22 à 16 53 15" src="https://user-images.githubusercontent.com/32447627/147159446-208a8b3a-04b6-4143-83fc-8a41464e960e.png">
+
+The files obtained during the process (segmentation, processed volumes or deformation fields) are organised into different folders. Two parameters at the beginning of the shell script are monitoring the organisation of the output files in the `anat` folder:
+- `DEBUGGING` 
+    - if set to 1, all the files are saved and stored into 4 different folders: `res`, `origin`, `add_res` and `seg`.
+    - if set to 0, only the input (original) volumes and the registered ones are saved in the folders `origin` and `res` respectively.
+- `KEEP_ORI_NAMING_LOC`
+    - if set to 1, the registered volumes are saved with the same name and path as the input volumes. Therefore, the `res` folder is deleted. This may be useful if we want to use the dataset for additional computations once the volumes have been registered.
+    - if set to 0, nothing happen. 
+
+**To run the shell script**, [`sct_run_batch`](https://spinalcordtoolbox.com/user_section/command-line.html#sct-run-batch) from SCT is used.  
 In the project directory, if your BIDS dataset is in the same directory in the `bids_dataset` folder, you can execute the following command to run the registration and evaluation pipeline:
 ```
 sct_run_batch -jobs 1 -path-data bids_dataset -path-out res_registration -script pipeline_bids_register_evaluate.sh
 ```
 
 ⚠️ To use this pipeline you should [install SCT](https://spinalcordtoolbox.com/user_section/installation.html) and have it active in your working environment when running the shell script. The script has been tested with SCT version [5.4](https://github.com/spinalcordtoolbox/spinalcordtoolbox/releases/tag/5.4). 
-
-

--- a/eval_reg_on_sc_seg.py
+++ b/eval_reg_on_sc_seg.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
     p.add_argument('--append', type=int, required=False, default=1, choices=[0, 1],
                    help="Append results as a new line in the output csv file instead of overwriting it.")
 
-    p.add_argument('--min-dice', required=False, type=int, default=80,
+    p.add_argument('--min-dice', required=False, type=int, default=0,
                    help="Minimum Dice score expected (percentage, to deal with int). If lower and not last-eval then "
                         "return a sys.exit(1) to signal this low score in the bash script and proceed to an "
                         "affine registration prior to the model's one")

--- a/pipeline_bids_register_evaluate.sh
+++ b/pipeline_bids_register_evaluate.sh
@@ -11,7 +11,7 @@
 
 set -x
 # Immediately exit if error
-set -e -o pipefail
+# set -e -o pipefail
 
 # Exit if user presses CTRL+C (Linux, OSX)
 trap "echo Caught Keyboard Interrupt within script. Exiting now.; exit" INT
@@ -46,7 +46,6 @@ compute_metrics(){
   echo "Compute metrics on segmentation"
   # Compute metrics
   sct_process_segmentation -i ${file}.nii.gz -o ${out}.csv -perslice 0 -angle-corr 1 -append 1
-
 }
 
 # SCRIPT STARTS HERE
@@ -69,6 +68,8 @@ file_t1_before_proc="${SES}_T1w"
 file_t2_before_proc="${SES}_T2w"
 
 REGISTRATION_MODEL="registration_model.h5"
+# Set the following value to 0 to not perform affine registration in any case
+MIN_SC_DICE_EXPECTED_PERC=80
 
 CONDA_BASE=$(conda info --base)
 source $CONDA_BASE/etc/profile.d/conda.sh
@@ -92,10 +93,67 @@ file_t2_reg_seg="${SES}_T2w_proc_reg_to_T1w_seg"
 
 conda activate smenv
 # Compute Dice score of SC segmentation overlap before and after registration and save the results in a csv file
-python $PATH_SCRIPT/eval_reg_on_sc_seg.py --fx-seg-path $file_t1_seg --moving-seg-path $file_t2_seg --warped-seg-path $file_t2_reg_seg --sub-id ${SES} --out-file $PATH_DATA_PROCESSED/dice_score.csv --append 1
-# Compute the normalized Mutual Information and save the results in a csv file
-python $PATH_SCRIPT/eval_reg_with_mi.py --fx-im-path $file_t1_seg --moving-im-path $file_t2_seg --warped-im-path $file_t2_reg_seg --sub-id ${SES} --out-file $PATH_DATA_PROCESSED/nmi.csv --append 1
+python $PATH_SCRIPT/eval_reg_on_sc_seg.py --fx-seg-path $file_t1_seg --moving-seg-path $file_t2_seg --warped-seg-path $file_t2_reg_seg --sub-id ${SES} --out-file $PATH_DATA_PROCESSED/dice_score.csv --append 1 --min-dice $MIN_SC_DICE_EXPECTED_PERC --last-eval 0
+RETURN_VAL=$?
 conda deactivate
+
+# If the Dice Score obtained after the model's registration is below MIN_SC_DICE_EXPECTED_PERC/100,
+# then perform an affine registration before doing the model's registration
+if [ $RETURN_VAL == 1 ]
+then
+
+  echo Perform affine registration prior to model registration
+  # Compute the SC segmentation
+  segment $file_t1_before_proc "t1"
+  segment $file_t2_before_proc "t2"
+
+  # Set the different filenames for the multimodal affine registration based on the SC segmentation
+  file_t1_before_proc="${SES}_T1w.nii.gz"
+  file_t2_before_proc="${SES}_T2w.nii.gz"
+  file_t1_before_proc_seg="${SES}_T1w_seg.nii.gz"
+  file_t2_before_proc_seg="${SES}_T2w_seg.nii.gz"
+  t2_affine_reg="${SES}_T2w_aff_reg.nii.gz"
+
+  # Multimodal affine registration based on the SC segmentation
+  sct_register_multimodal -i $file_t2_before_proc -iseg $file_t2_before_proc_seg -d $file_t1_before_proc -dseg $file_t1_before_proc_seg -param step=1,type=seg,algo=centermass -o $t2_affine_reg
+
+  # Set the different filenames for the registration using synthmorph approach
+  file_t1_before_proc="${SES}_T1w"
+  file_t2_before_proc="${SES}_T2w_aff_reg"
+
+  conda activate smenv
+  # Perform processing and model's registration
+  python $PATH_SCRIPT/bids_registration.py --model-path $PATH_SCRIPT/model/$REGISTRATION_MODEL --fx-img-path $file_t1_before_proc --mov-img-path $file_t2_before_proc --fx-img-contrast T1w --one-cpu-tf False
+  conda deactivate
+
+  file_t1="${SES}_T1w_proc"
+  file_t2="${SES}_T2w_aff_reg_proc"
+  file_t2_reg="${SES}_T2w_aff_reg_proc_reg_to_T1w"
+
+  # Segment spinal cord
+  segment $file_t1 "t1"
+  segment $file_t2 "t2"
+  segment $file_t2_reg "t2"
+
+  file_t1_seg="${SES}_T1w_proc_seg"
+  file_t2_seg="${SES}_T2w_aff_reg_proc_seg"
+  file_t2_reg_seg="${SES}_T2w_aff_reg_proc_reg_to_T1w_seg"
+
+  conda activate smenv
+  # Compute Dice score of SC segmentation overlap before and after registration and save the results in a csv file
+  python $PATH_SCRIPT/eval_reg_on_sc_seg.py --fx-seg-path $file_t1_seg --moving-seg-path $file_t2_seg --warped-seg-path $file_t2_reg_seg --sub-id ${SES} --out-file $PATH_DATA_PROCESSED/dice_score.csv --append 1
+  # Compute the normalized Mutual Information and save the results in a csv file
+  python $PATH_SCRIPT/eval_reg_with_mi.py --fx-im-path $file_t1_seg --moving-im-path $file_t2_seg --warped-im-path $file_t2_reg_seg --sub-id ${SES} --out-file $PATH_DATA_PROCESSED/nmi.csv --append 1
+  conda deactivate
+
+else
+
+  conda activate smenv
+  # Compute the normalized Mutual Information and save the results in a csv file
+  python $PATH_SCRIPT/eval_reg_with_mi.py --fx-im-path $file_t1_seg --moving-im-path $file_t2_seg --warped-im-path $file_t2_reg_seg --sub-id ${SES} --out-file $PATH_DATA_PROCESSED/nmi.csv --append 1
+  conda deactivate
+
+fi
 
 # Compute metrics
 compute_metrics "$file_t1_seg" "$PATH_DATA_PROCESSED/t1_seg"

--- a/pipeline_bids_register_evaluate.sh
+++ b/pipeline_bids_register_evaluate.sh
@@ -55,6 +55,12 @@ sct_check_dependencies -short
 
 SUBJECT_ID=$(dirname "$SUBJECT")
 SES=$(basename "$SUBJECT")
+
+# Choose the registration model to use (should be in the model folder)
+REGISTRATION_MODEL="registration_model.h5"
+# Set the following value to 0 to not perform affine registration in any case
+MIN_SC_DICE_EXPECTED_PERC=80
+
 # Go to folder where data will be copied and processed
 cd ${PATH_DATA_PROCESSED}
 # Copy source images
@@ -66,10 +72,6 @@ cd ${SUBJECT}/anat/
 
 file_t1_before_proc="${SES}_T1w"
 file_t2_before_proc="${SES}_T2w"
-
-REGISTRATION_MODEL="registration_model.h5"
-# Set the following value to 0 to not perform affine registration in any case
-MIN_SC_DICE_EXPECTED_PERC=80
 
 CONDA_BASE=$(conda info --base)
 source $CONDA_BASE/etc/profile.d/conda.sh

--- a/pipeline_bids_register_evaluate.sh
+++ b/pipeline_bids_register_evaluate.sh
@@ -11,7 +11,7 @@
 
 set -x
 # Immediately exit if error
-# set -e -o pipefail
+set -e -o pipefail
 
 # Exit if user presses CTRL+C (Linux, OSX)
 trap "echo Caught Keyboard Interrupt within script. Exiting now.; exit" INT
@@ -94,8 +94,10 @@ file_t2_reg_seg="${SES}_T2w_proc_reg_to_T1w_seg"
 
 conda activate smenv
 # Compute Dice score of SC segmentation overlap before and after registration and save the results in a csv file
+set +e +o pipefail
 python $PATH_SCRIPT/eval_reg_on_sc_seg.py --fx-seg-path $file_t1_seg --moving-seg-path $file_t2_seg --warped-seg-path $file_t2_reg_seg --sub-id ${SES} --out-file $PATH_DATA_PROCESSED/dice_score.csv --append 1 --min-dice $MIN_SC_DICE_EXPECTED_PERC --last-eval 0
 RETURN_VAL=$?
+set -e -o pipefail
 conda deactivate
 
 # If the Dice Score obtained after the model's registration is below MIN_SC_DICE_EXPECTED_PERC/100,
@@ -138,7 +140,9 @@ then
 
   conda activate smenv
   # Compute Dice score of SC segmentation overlap before and after registration and save the results in a csv file
+  set +e +o pipefail
   python $PATH_SCRIPT/eval_reg_on_sc_seg.py --fx-seg-path $file_t1_seg --moving-seg-path $file_t2_seg --warped-seg-path $file_t2_reg_seg --sub-id ${SES} --out-file $PATH_DATA_PROCESSED/dice_score.csv --append 1
+  set -e -o pipefail
   # Compute the normalized Mutual Information and save the results in a csv file
   python $PATH_SCRIPT/eval_reg_with_mi.py --fx-im-path $file_t1_seg --moving-im-path $file_t2_seg --warped-im-path $file_t2_reg_seg --sub-id ${SES} --out-file $PATH_DATA_PROCESSED/nmi.csv --append 1
   conda deactivate

--- a/pipeline_bids_register_evaluate.sh
+++ b/pipeline_bids_register_evaluate.sh
@@ -39,15 +39,6 @@ segment(){
   sct_deepseg_sc -i ${file}.nii.gz -c $contrast -qc ${PATH_QC} -qc-subject ${SUBJECT}
 }
 
-compute_metrics(){
-  local file="$1"
-  local out="$2"
-
-  echo "Compute metrics on segmentation"
-  # Compute metrics
-  sct_process_segmentation -i ${file}.nii.gz -o ${out}.csv -perslice 0 -angle-corr 1 -append 1
-}
-
 # SCRIPT STARTS HERE
 # ==============================================================================
 # Display useful info for the log, such as SCT version, RAM and CPU cores available
@@ -156,11 +147,6 @@ else
   conda deactivate
 
 fi
-
-# Compute metrics
-compute_metrics "$file_t1_seg" "$PATH_DATA_PROCESSED/t1_seg"
-compute_metrics "$file_t2_seg" "$PATH_DATA_PROCESSED/t2_seg"
-compute_metrics "$file_t2_reg_seg" "$PATH_DATA_PROCESSED/t2_reg_seg"
 
 # Generate QC report to assess registration
 sct_qc -i ${file_t1}.nii.gz -s ${file_t1_seg}.nii.gz -d ${file_t2}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}

--- a/pipeline_bids_register_evaluate.sh
+++ b/pipeline_bids_register_evaluate.sh
@@ -109,17 +109,14 @@ then
   segment $file_t2_before_proc "t2"
 
   # Set the different filenames for the multimodal affine registration based on the SC segmentation
-  file_t1_before_proc="${SES}_T1w.nii.gz"
-  file_t2_before_proc="${SES}_T2w.nii.gz"
   file_t1_before_proc_seg="${SES}_T1w_seg.nii.gz"
   file_t2_before_proc_seg="${SES}_T2w_seg.nii.gz"
   t2_affine_reg="${SES}_T2w_aff_reg.nii.gz"
 
   # Multimodal affine registration based on the SC segmentation
-  sct_register_multimodal -i $file_t2_before_proc -iseg $file_t2_before_proc_seg -d $file_t1_before_proc -dseg $file_t1_before_proc_seg -param step=1,type=seg,algo=centermass -o $t2_affine_reg
+  sct_register_multimodal -i "${file_t2_before_proc}.nii.gz" -iseg $file_t2_before_proc_seg -d "${file_t1_before_proc}.nii.gz" -dseg $file_t1_before_proc_seg -param step=1,type=seg,algo=centermass -o $t2_affine_reg
 
   # Set the different filenames for the registration using synthmorph approach
-  file_t1_before_proc="${SES}_T1w"
   file_t2_before_proc="${SES}_T2w_aff_reg"
 
   conda activate smenv
@@ -127,7 +124,6 @@ then
   python $PATH_SCRIPT/bids_registration.py --model-path $PATH_SCRIPT/model/$REGISTRATION_MODEL --fx-img-path $file_t1_before_proc --mov-img-path $file_t2_before_proc --fx-img-contrast T1w --one-cpu-tf False
   conda deactivate
 
-  file_t1="${SES}_T1w_proc"
   file_t2="${SES}_T2w_aff_reg_proc"
   file_t2_reg="${SES}_T2w_aff_reg_proc_reg_to_T1w"
 

--- a/pipeline_bids_register_evaluate_opt_affine.sh
+++ b/pipeline_bids_register_evaluate_opt_affine.sh
@@ -57,6 +57,8 @@ DEBUGGING=1
 KEEP_ORI_NAMING_LOC=1
 # Choose the registration model to use (should be in the model folder)
 REGISTRATION_MODEL="registration_model.h5"
+# Set the following value to 0 to not perform affine registration in any case
+MIN_SC_DICE_EXPECTED_PERC=80
 
 # Go to folder where data will be copied and processed
 cd ${PATH_DATA_PROCESSED}
@@ -92,10 +94,67 @@ file_t2_reg_seg="${SES}_T2w_proc_reg_to_T1w_seg"
 
 conda activate smenv
 # Compute Dice score of SC segmentation overlap before and after registration and save the results in a csv file
-python $PATH_SCRIPT/eval_reg_on_sc_seg.py --fx-seg-path $file_t1_seg --moving-seg-path $file_t2_seg --warped-seg-path $file_t2_reg_seg --sub-id ${SES} --out-file $PATH_DATA_PROCESSED/dice_score.csv --append 1
-# Compute the normalized Mutual Information and save the results in a csv file
-python $PATH_SCRIPT/eval_reg_with_mi.py --fx-im-path $file_t1_seg --moving-im-path $file_t2_seg --warped-im-path $file_t2_reg_seg --sub-id ${SES} --out-file $PATH_DATA_PROCESSED/nmi.csv --append 1
+set +e +o pipefail
+python $PATH_SCRIPT/eval_reg_on_sc_seg.py --fx-seg-path $file_t1_seg --moving-seg-path $file_t2_seg --warped-seg-path $file_t2_reg_seg --sub-id ${SES} --out-file $PATH_DATA_PROCESSED/dice_score.csv --append 1 --min-dice $MIN_SC_DICE_EXPECTED_PERC --last-eval 0
+RETURN_VAL=$?
+set -e -o pipefail
 conda deactivate
+
+# If the Dice Score obtained after the model's registration is below MIN_SC_DICE_EXPECTED_PERC/100,
+# then perform an affine registration before doing the model's registration
+if [ $RETURN_VAL == 1 ]
+then
+
+  echo Perform affine registration prior to model registration
+  # Compute the SC segmentation
+  segment $file_t1_before_proc "t1"
+  segment $file_t2_before_proc "t2"
+
+  # Set the different filenames for the multimodal affine registration based on the SC segmentation
+  file_t1_before_proc_seg="${SES}_T1w_seg.nii.gz"
+  file_t2_before_proc_seg="${SES}_T2w_seg.nii.gz"
+  t2_affine_reg="${SES}_T2w_aff_reg.nii.gz"
+
+  # Multimodal affine registration based on the SC segmentation
+  sct_register_multimodal -i "${file_t2_before_proc}.nii.gz" -iseg $file_t2_before_proc_seg -d "${file_t1_before_proc}.nii.gz" -dseg $file_t1_before_proc_seg -param step=1,type=seg,algo=centermass -o $t2_affine_reg
+
+  # Set the different filenames for the registration using synthmorph approach
+  file_t2_before_proc="${SES}_T2w_aff_reg"
+
+  conda activate smenv
+  # Perform processing and model's registration
+  python $PATH_SCRIPT/bids_registration.py --model-path $PATH_SCRIPT/model/$REGISTRATION_MODEL --fx-img-path $file_t1_before_proc --mov-img-path $file_t2_before_proc --fx-img-contrast T1w --one-cpu-tf False
+  conda deactivate
+
+  file_t2="${SES}_T2w_aff_reg_proc"
+  file_t2_reg="${SES}_T2w_aff_reg_proc_reg_to_T1w"
+
+  # Segment spinal cord
+  segment $file_t1 "t1"
+  segment $file_t2 "t2"
+  segment $file_t2_reg "t2"
+
+  file_t1_seg="${SES}_T1w_proc_seg"
+  file_t2_seg="${SES}_T2w_aff_reg_proc_seg"
+  file_t2_reg_seg="${SES}_T2w_aff_reg_proc_reg_to_T1w_seg"
+
+  conda activate smenv
+  # Compute Dice score of SC segmentation overlap before and after registration and save the results in a csv file
+  set +e +o pipefail
+  python $PATH_SCRIPT/eval_reg_on_sc_seg.py --fx-seg-path $file_t1_seg --moving-seg-path $file_t2_seg --warped-seg-path $file_t2_reg_seg --sub-id ${SES} --out-file $PATH_DATA_PROCESSED/dice_score.csv --append 1
+  set -e -o pipefail
+  # Compute the normalized Mutual Information and save the results in a csv file
+  python $PATH_SCRIPT/eval_reg_with_mi.py --fx-im-path $file_t1_seg --moving-im-path $file_t2_seg --warped-im-path $file_t2_reg_seg --sub-id ${SES} --out-file $PATH_DATA_PROCESSED/nmi.csv --append 1
+  conda deactivate
+
+else
+
+  conda activate smenv
+  # Compute the normalized Mutual Information and save the results in a csv file
+  python $PATH_SCRIPT/eval_reg_with_mi.py --fx-im-path $file_t1_seg --moving-im-path $file_t2_seg --warped-im-path $file_t2_reg_seg --sub-id ${SES} --out-file $PATH_DATA_PROCESSED/nmi.csv --append 1
+  conda deactivate
+
+fi
 
 # Generate QC report to assess registration
 sct_qc -i ${file_t1}.nii.gz -s ${file_t1_seg}.nii.gz -d ${file_t2}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
@@ -115,7 +174,12 @@ mv "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T2w.json" "${PATH_DATA_PROCESS
 
 mkdir res
 mv "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T1w_proc.nii.gz" "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${SES}_T1w_proc.nii.gz"
-mv "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T2w_proc_reg_to_T1w.nii.gz" "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${SES}_T2w_proc_reg_to_T1w.nii.gz"
+if [ $RETURN_VAL == 0 ]
+then
+  mv "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T2w_proc_reg_to_T1w.nii.gz" "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${SES}_T2w_proc_reg_to_T1w.nii.gz"
+else
+  mv "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T2w_aff_reg_proc_reg_to_T1w.nii.gz" "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${SES}_T2w_aff_reg_proc_reg_to_T1w.nii.gz"
+fi
 
 if [ $DEBUGGING == 1 ]
 then
@@ -142,7 +206,12 @@ fi
 if [ $KEEP_ORI_NAMING_LOC == 1 ]
 then
   mv "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${SES}_T1w_proc.nii.gz" "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T1w.nii.gz"
-  mv "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${SES}_T2w_proc_reg_to_T1w.nii.gz" "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T2w.nii.gz"
+  if [ $RETURN_VAL == 0 ]
+  then
+    mv "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${SES}_T2w_proc_reg_to_T1w.nii.gz" "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T2w.nii.gz"
+  else
+    mv "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${SES}_T2w_aff_reg_proc_reg_to_T1w.nii.gz" "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T2w.nii.gz"
+  fi
   rm -rf "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/"
 fi
 
@@ -150,10 +219,18 @@ fi
 # ------------------------------------------------------------------------------
 if [ $KEEP_ORI_NAMING_LOC == 0 ]
 then
-  FILES_TO_CHECK=(
-    "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${SES}_T1w_proc.nii.gz"
-    "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${SES}_T2w_proc_reg_to_T1w.nii.gz"
-  )
+  if [ $RETURN_VAL == 0 ]
+  then
+    FILES_TO_CHECK=(
+      "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${SES}_T1w_proc.nii.gz"
+      "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${SES}_T2w_proc_reg_to_T1w.nii.gz"
+    )
+  else
+    FILES_TO_CHECK=(
+      "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${SES}_T1w_proc.nii.gz"
+      "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${SES}_T2w_aff_reg_proc_reg_to_T1w.nii.gz"
+    )
+  fi
 else
   FILES_TO_CHECK=(
     "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T1w.nii.gz"


### PR DESCRIPTION
Implementation of an affine registration step prior to the model's registration when the model's registration didn't lead to a Dice score as high as wanted (and specified in the bash script).  

Adding affine registration to the pipeline is time consuming because this step requires the computation of SC segmentations on the original volumes and is based on a method applied slice-wise. However, as the registration models are sometimes currently not really accurate when the input volumes are not in the same affine space, this additional step in the pipeline could ensure good results for a wider range of input data, including data initially in a different affine space.  

To avoid using the affine registration on any subjects, the argument `MIN_SC_DICE_EXPECTED_PERC` can be set to 0. Therefore, the addition of affine registration in the pipeline is optional and can be used as desired by the user. In general, a high `MIN_SC_DICE_EXPECTED_PERC` value (~85-90) would lead to the computation of the affine registration prior to the model's registration for a large number of subjects. This would cause the process to slow down. However, setting the `MIN_SC_DICE_EXPECTED_PERC` to a medium value (~50-60) would result in only a few computations of the affine registration for the subjects for whom the initial model's registration was not good. Thus, the process will not take much longer and the results for these subjects should be greatly improved. In this case, it seems that the trade-off between additional computation time and improved registration is beneficial. 

The affine registration step is done with [`sct_register_multimodal`](https://spinalcordtoolbox.com/user_section/command-line.html#sct-register-multimodal) from the [Spinal Cord Toolbox](https://spinalcordtoolbox.com/index.html) and using the centermass algorithm, which is a slice wise center of mass alignment done on the spinal cord segmentations (computed on the original input volumes).

<img width="1026" alt="Capture d’écran 2021-12-22 à 15 44 42" src="https://user-images.githubusercontent.com/32447627/147153002-18c83b5d-c412-47fc-a097-d370b24595fb.png">

In addition, the files obtained during the process (segmentation, processed volumes or deformation fields) have been reorganised into different folders. Two parameters at the beginning of the bash script are monitoring the organisation of the output files in the `anat` folder:
- `DEBUGGING` 
    - if set to 1, all the files are saved and stored into 4 different folders: `res`, `origin`, `add_res` and `seg`.
    - if set to 0, only the input (original) volumes and the registered ones are saved in the folders `origin` and `res` respectively.
- `KEEP_ORI_NAMING_LOC`
    - if set to 1, the registered volumes are saved with the same name and path as the input volumes. Therefore, the `res` folder is deleted. This may be useful if we want to use the dataset for additional computations once the volumes have been registered.
    - if set to 0, nothing happen. 