### PR TITLE
Inference on input of any size or subvolumes

### DIFF
--- a/3d_reg.py
+++ b/3d_reg.py
@@ -1,6 +1,6 @@
 """
 File to load a trained registration model and register two images together.
-It includes a preprocessing step to transform the volumes to the dimensions required by the model.
+It includes a preprocessing step to scale the volumes and set it to an isotropic resolution of 1mm as required by the model.
 """
 
 import os
@@ -11,33 +11,246 @@ import nibabel as nib
 import voxelmorph as vxm
 
 from nilearn.image import resample_img
+from scipy.ndimage import zoom
+from nibabel.processing import resample_from_to
 
 
-def preprocess(im_nii, in_shape=(160, 160, 192)):
-    ''' Resize and normalize image. '''
+def resample_nib(image, new_size=None, new_size_type=None, image_dest=None, interpolation='linear', mode='nearest'):
+    """
+    Resample a nibabel or Image object based on a specified resampling factor.
+    Can deal with 2d, 3d or 4d image objects.
+    Copyright (c) 2014 Polytechnique Montreal <www.neuro.polymtl.ca>
+    Authors: Julien Cohen-Adad, Sara Dupont
+
+    :param image: nibabel or Image image.
+    :param new_size: list of float: Resampling factor, final dimension or resolution, depending on new_size_type.
+    :param new_size_type: {'vox', 'factor', 'mm'}: Feature used for resampling. Examples:
+        new_size=[128, 128, 90], new_size_type='vox' --> Resampling to a dimension of 128x128x90 voxels
+        new_size=[2, 2, 2], new_size_type='factor' --> 2x isotropic upsampling
+        new_size=[1, 1, 5], new_size_type='mm' --> Resampling to a resolution of 1x1x5 mm
+    :param image_dest: Destination image to resample the input image to. In this case, new_size and new_size_type
+        are ignored
+    :param interpolation: {'nn', 'linear', 'spline'}. The interpolation type
+    :param mode: Outside values are filled with 0 ('constant') or nearest value ('nearest').
+    :return: The resampled nibabel or Image image (depending on the input object type).
+    """
+
+    # set interpolation method
+    dict_interp = {'nn': 0, 'linear': 1, 'spline': 2}
+
+    # If input is an Image object, create nibabel object from it
+    if type(image) == nib.nifti1.Nifti1Image:
+        img = image
+    else:
+        raise Exception(TypeError)
+
+    if image_dest is None:
+        # Get dimensions of data
+        p = img.header.get_zooms()
+        shape = img.header.get_data_shape()
+
+        if img.ndim == 4:
+            new_size += ['1']  # needed because the code below is general, i.e., does not assume 3d input and uses img.shape
+
+        # compute new shape based on specific resampling method
+        if new_size_type == 'vox':
+            shape_r = tuple([int(new_size[i]) for i in range(img.ndim)])
+        elif new_size_type == 'factor':
+            if len(new_size) == 1:
+                # isotropic resampling
+                new_size = tuple([new_size[0] for i in range(img.ndim)])
+            # compute new shape as: shape_r = shape * f
+            shape_r = tuple([int(np.round(shape[i] * float(new_size[i]))) for i in range(img.ndim)])
+        elif new_size_type == 'mm':
+            if len(new_size) == 1:
+                # isotropic resampling
+                new_size = tuple([new_size[0] for i in range(img.ndim)])
+            # compute new shape as: shape_r = shape * (p_r / p)
+            shape_r = tuple([int(np.round(shape[i] * float(p[i]) / float(new_size[i]))) for i in range(img.ndim)])
+        else:
+            raise ValueError("'new_size_type' is not recognized.")
+
+        # Generate 3d affine transformation: R
+        affine = img.affine[:4, :4]
+        affine[3, :] = np.array([0, 0, 0, 1])  # satisfy to nifti convention. Otherwise it grabs the temporal
+        # logger.debug('Affine matrix: \n' + str(affine))
+        R = np.eye(4)
+        for i in range(3):
+            try:
+                R[i, i] = img.shape[i] / float(shape_r[i])
+            except ZeroDivisionError:
+                raise ZeroDivisionError("Destination size is zero for dimension {}. You are trying to resample to an "
+                                        "unrealistic dimension. Check your NIFTI pixdim values to make sure they are "
+                                        "not corrupted.".format(i))
+
+        affine_r = np.dot(affine, R)
+        reference = (shape_r, affine_r)
+
+    # If reference is provided
+    else:
+        if type(image_dest) == nib.nifti1.Nifti1Image:
+            reference = image_dest
+        else:
+            raise Exception(TypeError)
+
+    if img.ndim == 3:
+        # we use mode 'nearest' to overcome issue #2453
+        img_r = resample_from_to(img, to_vox_map=reference, order=dict_interp[interpolation],
+                                 mode=mode, cval=0.0, out_class=None)
+
+    elif img.ndim == 4:
+        # Import here instead of top of the file because this is an isolated case and nibabel takes time to import
+        data4d = np.zeros(shape_r)
+        # Loop across 4th dimension and resample each 3d volume
+        for it in range(img.shape[3]):
+            # Create dummy 3d nibabel image
+            nii_tmp = nib.nifti1.Nifti1Image(img.get_data()[..., it], affine)
+            img3d_r = resample_from_to(nii_tmp, to_vox_map=(shape_r[:-1], affine_r),
+                                       order=dict_interp[interpolation], mode=mode, cval=0.0, out_class=None)
+            data4d[..., it] = img3d_r.get_data()
+        # Create 4d nibabel Image
+        img_r = nib.nifti1.Nifti1Image(data4d, affine_r)
+        # Copy over the TR parameter from original 4D image (otherwise it will be incorrectly set to 1)
+        img_r.header.set_zooms(list(img_r.header.get_zooms()[0:3]) + [img.header.get_zooms()[3]])
+
+    return img_r
+
+
+def preprocess(data, im_nii, mov_im_nii):
+    """
+    Scale volumes and create subvolumes of the correct shape.
+    Return the preprocessed volumes (scaling, zero-padding, isotropic resolution of 1mm) as well as the
+    list of subvolumes for the fixed image, list of subvolumes for moving image and the coordinates of the subvolumes.
+    """
 
     # Scale the data between 0 and 1
-    img = im_nii.get_fdata()
-    scaled_img = (img - np.min(img)) / (np.max(img) - np.min(img))
-    scaled_nii = nib.Nifti1Image(scaled_img, im_nii.affine)
+    fx_img = im_nii.get_fdata()
+    scaled_fx_img = (fx_img - np.min(fx_img)) / (np.max(fx_img) - np.min(fx_img))
 
-    # sampling strategy: https://www.kaggle.com/mechaman/resizing-reshaping-and-resampling-nifti-files
-    target_shape = np.array(in_shape)
-    new_resolution = [1, 1, 1]
-    new_affine = np.zeros((4, 4))
-    new_affine[:3, :3] = np.diag(new_resolution)
-    # putting point 0,0,0 in the middle of the new volume - this could be refined in the future
-    new_affine[:3, 3] = target_shape*new_resolution/2.*-1
-    new_affine[3, 3] = 1.
+    mov_img = mov_im_nii.get_fdata()
+    scaled_mov_img = (mov_img - np.min(mov_img)) / (np.max(mov_img) - np.min(mov_img))
 
-    # Resample the 3d image to be in the dimension expected by the registration model
-    resampled_nii = resample_img(scaled_nii, target_affine=new_affine,
-                                 target_shape=target_shape, interpolation='nearest')
+    # Change the resolution to isotropic 1 mm resolution
+    fx_resampled_nii = resample_nib(nib.Nifti1Image(scaled_fx_img, im_nii.affine), new_size=[1, 1, 1],
+                                    new_size_type='mm', image_dest=None, interpolation='linear', mode='constant')
+    fx_img_res111 = fx_resampled_nii.get_fdata()
+    mov_resampled_nii = resample_nib(nib.Nifti1Image(scaled_mov_img, mov_im_nii.affine),
+                                     image_dest=fx_resampled_nii, interpolation='linear', mode='constant')
+    mov_img_res111 = mov_resampled_nii.get_fdata()
 
-    return resampled_nii
+    # Ensure that the volumes can be used in the registration model
+    fx_img_shape = fx_img_res111.shape
+    mov_img_shape = mov_img_res111.shape
+    max_img_shape = max(fx_img_shape, mov_img_shape)
+    new_img_shape = (int(np.ceil(max_img_shape[0] // 16)) * 16, int(np.ceil(max_img_shape[1] // 16)) * 16,
+                     int(np.ceil(max_img_shape[2] // 16)) * 16)
+
+    # Pad the volumes to the max shape
+    fx_resampled_nii = resample_img(fx_resampled_nii, target_affine=fx_resampled_nii.affine,
+                                    target_shape=new_img_shape, interpolation='continuous')
+    fx_img_res111 = fx_resampled_nii.get_fdata()
+    mov_resampled_nii = resample_img(mov_resampled_nii, target_affine=mov_resampled_nii.affine,
+                                     target_shape=new_img_shape, interpolation='continuous')
+    mov_img_res111 = mov_resampled_nii.get_fdata()
+
+    if data['use_subvol']:
+
+        in_shape = (int(np.ceil(data['subvol_size'][0] // 16)) * 16, int(np.ceil(data['subvol_size'][1] // 16)) * 16,
+                    int(np.ceil(data['subvol_size'][2] // 16)) * 16)
+
+        # Determine how many subvolumes have to be created
+        shape_in_vol = fx_img_res111.shape
+        min_perc = 0.1
+
+        nb_sub_x_axis = int(shape_in_vol[0] / (in_shape[0] - min_perc * in_shape[0])) + 1
+        nb_sub_y_axis = int(shape_in_vol[1] / (in_shape[1] - min_perc * in_shape[1])) + 1
+        nb_sub_z_axis = int(shape_in_vol[2] / (in_shape[2] - min_perc * in_shape[2])) + 1
+
+        # Determine the number of overlapping voxels for each axis
+        x_vox_overlap, y_vox_overlap, z_vox_overlap = 0, 0, 0
+        if nb_sub_x_axis > 1:
+            x_vox_overlap = (in_shape[0] - (shape_in_vol[0]/nb_sub_x_axis)) * (nb_sub_x_axis/(nb_sub_x_axis - 1))
+        if nb_sub_y_axis > 1:
+            y_vox_overlap = (in_shape[1] - (shape_in_vol[1]/nb_sub_y_axis)) * (nb_sub_y_axis/(nb_sub_y_axis - 1))
+        if nb_sub_z_axis > 1:
+            z_vox_overlap = (in_shape[2] - (shape_in_vol[2]/nb_sub_z_axis)) * (nb_sub_z_axis/(nb_sub_z_axis - 1))
+
+        # Get the subvolumes and the coordinates of the x_min, x_max, y_min, y_max, z_min, z_max
+        lst_subvol_fx = []
+        lst_subvol_mov = []
+        lst_coords_subvol = []
+
+        x_max, y_max, z_max = 0, 0, 0
+        for i in range(nb_sub_x_axis):
+            x_min = 0 if i == 0 else int(x_max - x_vox_overlap)
+            x_max = int(x_min + in_shape[0])
+            for j in range(nb_sub_y_axis):
+                y_min = 0 if j == 0 else int(y_max - y_vox_overlap)
+                y_max = int(y_min + in_shape[1])
+                for k in range(nb_sub_z_axis):
+                    z_min = 0 if k == 0 else int(z_max - z_vox_overlap)
+                    z_max = int(z_min + in_shape[2])
+                    subvol_fx = fx_img_res111[x_min:x_max, y_min:y_max, z_min:z_max]
+                    subvol_mov = mov_img_res111[x_min:x_max, y_min:y_max, z_min:z_max]
+
+                    lst_subvol_fx.append(subvol_fx)
+                    lst_subvol_mov.append(subvol_mov)
+                    lst_coords_subvol.append((x_min, x_max, y_min, y_max, z_min, z_max))
+    else:
+        lst_subvol_fx, lst_subvol_mov, lst_coords_subvol = [], [], []
+
+    return fx_resampled_nii, mov_resampled_nii, lst_subvol_fx, lst_subvol_mov, lst_coords_subvol
 
 
-def run_main(model_path, fx_im_path, mov_im_path, res_dir='res',
+def get_def_field_from_subvol(model_in_shape, im_shape, lst_coords_subvol, lst_warp_subvol):
+    """
+    Create a map of weights, apply it on the warping fields obtained with the different subvolumes,
+    construct the final warping field and return it
+    """
+    # Create a map of weights that will be applied on the different warping fields to reduce the boundaries effect
+    # via a weighted average of the overlapping volumes (between the volumes) giving more weights to the inside part
+    x, y, z = model_in_shape[0]//2, model_in_shape[1]//2, model_in_shape[2]//2
+    grid = np.mgrid[-x:x, -y:y, -z:z]
+    w_map = np.maximum(np.abs(grid[0]), np.abs(grid[1]))
+    w_map = np.maximum(w_map, np.abs(grid[2]))
+    # The center of the volume has a weight of 1 and then it decreases linearly towards the boundaries
+    w_map = 1 - w_map/(np.max(w_map) + 1)
+
+    # Get the map representing the weights of all the subvolumes and place the map to the correct location of each
+    # subvolume
+    sum_weights = np.zeros((im_shape[0], im_shape[1], im_shape[2]))
+    w_map_subvol_lst = []
+    warp_subvol_lst = []
+    for coords, warp in zip(lst_coords_subvol, lst_warp_subvol):
+        w_map_subvol = np.zeros((im_shape[0], im_shape[1], im_shape[2]))
+        warp_field_tmp = np.zeros((im_shape[0], im_shape[1], im_shape[2], 3))
+        x_min, x_max, y_min, y_max, z_min, z_max = coords
+        sum_weights[x_min:x_max, y_min:y_max, z_min:z_max] += w_map
+        w_map_subvol[x_min:x_max, y_min:y_max, z_min:z_max] = w_map
+        warp_field_tmp[x_min:x_max, y_min:y_max, z_min:z_max, :] = warp
+        w_map_subvol_lst.append(w_map_subvol)
+        warp_subvol_lst.append(warp_field_tmp)
+
+    # To avoid division by 0, replace the sum weights that are 0 by 1 before the division (may appear for the voxels
+    # at the border of the original volume if the size of this latter is even on certain axes)
+    sum_weights[sum_weights == 0] = 1
+
+    # Divide the weight map of each subvolume by the sum of all the weights of the different subvolumes to determine
+    # the relative weight of each subvolume in the prediction of the final displacement vector
+    w_map_subvol_final_lst = []
+    for w_map_subvol in w_map_subvol_lst:
+        w_map_subvol_final_lst.append(w_map_subvol/sum_weights)
+
+    # Reconstruct the warping field
+    warp_field = np.zeros((im_shape[0], im_shape[1], im_shape[2], 3))
+    for w_subvol, warp in zip(w_map_subvol_final_lst, warp_subvol_lst):
+        for i in range(3):
+            warp_field[..., i] += w_subvol * warp[..., i]
+
+    return warp_field
+
+
+def run_main(data, model_path, fx_im_path, mov_im_path, res_dir='res',
              out_im_path='warped_im', out_field_path='deform_field'):
     """
     Load a registration model, preprocess the two images and register the moving image to the fixed one.
@@ -45,29 +258,98 @@ def run_main(model_path, fx_im_path, mov_im_path, res_dir='res',
     """
 
     model = vxm.networks.VxmDense.load(model_path, input_model=None)
-
     reg_model = model
-    model_in_shape = reg_model.inputs[0].shape[1:-1]
-
-    fixed_nii = nib.load(f'{fx_im_path}.nii.gz')
-    moving_nii = nib.load(f'{mov_im_path}.nii.gz')
-
-    fixed = preprocess(fixed_nii, model_in_shape)
-    moving = preprocess(moving_nii, model_in_shape)
-
-    moved, warp = reg_model.predict([np.expand_dims(moving.get_fdata().squeeze(), axis=(0, -1)),
-                                     np.expand_dims(fixed.get_fdata().squeeze(), axis=(0, -1))])
-
-    nib.save(fixed, os.path.join(f'{fx_im_path}_preproc.nii.gz'))
-    nib.save(moving, os.path.join(f'{mov_im_path}_preproc.nii.gz'))
-
-    moved = nib.Nifti1Image(moved[0, ..., 0], fixed.affine)
-    warp = nib.Nifti1Image(warp[0, ...], fixed.affine)
 
     os.makedirs(res_dir, exist_ok=True)
+    moved_path = os.path.join(res_dir, f'{out_im_path}.nii.gz')
+    warp_path = os.path.join(res_dir, f'{out_field_path}.nii.gz')
 
-    nib.save(moved, os.path.join(res_dir, f'{out_im_path}.nii.gz'))
-    nib.save(warp, os.path.join(res_dir, f'{out_field_path}.nii.gz'))
+    fixed_nii = nib.load(fx_im_path)
+    moving_nii = nib.load(mov_im_path)
+
+    fixed, moving, lst_subvol_fx, lst_subvol_mov, lst_coords_subvol = \
+        preprocess(data, fixed_nii, moving_nii)
+
+    # nib.save(fixed, os.path.join(f'{fx_im_path}_proc.nii.gz'))
+    # nib.save(moving, os.path.join(f'{mov_im_path}_proc.nii.gz'))
+
+    if data['use_subvol']:
+        model_in_shape = (int(np.ceil(data['subvol_size'][0] // 16)) * 16, int(np.ceil(data['subvol_size'][1] // 16)) * 16,
+                          int(np.ceil(data['subvol_size'][2] // 16)) * 16)
+    else:
+        model_in_shape = fixed.get_fdata().shape
+
+    reg_args = dict(
+        inshape=model_in_shape,
+        int_steps=data['int_steps'],
+        int_resolution=data['int_res'],
+        svf_resolution=data['svf_res'],
+        nb_unet_features=(data['enc'], data['dec'])
+    )
+
+    model = vxm.networks.VxmDense(**reg_args)
+    model.set_weights(reg_model.get_weights())
+
+    if not data['use_subvol']:
+        moved, warp = model.predict([np.expand_dims(moving.get_fdata().squeeze(), axis=(0, -1)),
+                                     np.expand_dims(fixed.get_fdata().squeeze(), axis=(0, -1))])
+        warp_data = warp[0, ...]
+        is_warp_half_res = False if warp_data.shape[0] == model_in_shape[0] else True
+        if is_warp_half_res:
+            warp_data = zoom(warp_data, (2, 2, 2, 1))
+        warp = nib.Nifti1Image(warp_data, fixed.affine)
+        # moved_nii = nib.Nifti1Image(moved[0, ..., 0], fixed.affine)
+        # nib.save(moved_nii, os.path.join(f'{mov_im_path}_proc_reg_to_{fx_contrast}.nii.gz'))
+        # nib.save(warp, os.path.join(f'{mov_im_path}_proc_field_to_{fx_contrast}.nii.gz'))
+        warp_in_original_space = resample_img(warp, target_affine=moving_nii.affine,
+                                              target_shape=moving_nii.get_fdata().shape, interpolation='continuous')
+        nib.save(warp_in_original_space, warp_path)
+    else:
+        warp_field_lst = []
+        for fx_subvol, mov_subvol in zip(lst_subvol_fx, lst_subvol_mov):
+            _, warp = model.predict([np.expand_dims(mov_subvol.squeeze(), axis=(0, -1)),
+                                     np.expand_dims(fx_subvol.squeeze(), axis=(0, -1))])
+            warp_field_lst.append(warp[0, ...])
+
+        is_warp_half_res = False if warp_field_lst[0].shape[0] == model_in_shape[0] else True
+
+        if is_warp_half_res:
+            warp_field_lst_good_dim = []
+            for warp in warp_field_lst:
+                warp_field_lst_good_dim.append(zoom(warp, (2, 2, 2, 1)))
+        else:
+            warp_field_lst_good_dim = warp_field_lst
+
+        warp_field = get_def_field_from_subvol(model_in_shape, moving.shape, lst_coords_subvol, warp_field_lst_good_dim)
+
+        def_field_nii = nib.Nifti1Image(warp_field, affine=fixed.affine)
+        nib.save(def_field_nii, os.path.join(f'{mov_im_path}_proc_field.nii.gz'))
+        warp_in_original_space = resample_img(def_field_nii, target_affine=moving_nii.affine,
+                                              target_shape=moving_nii.get_fdata().shape, interpolation='continuous')
+        nib.save(warp_in_original_space, warp_path)
+
+        nib.save(moving, os.path.join(f'{mov_im_path}_proc.nii.gz'))
+        moving = vxm.py.utils.load_volfile(os.path.join(f'{mov_im_path}_proc.nii.gz'),
+                                           add_batch_axis=True, add_feat_axis=True)
+        warp_to_apply = vxm.py.utils.load_volfile(os.path.join(f'{mov_im_path}_proc_field.nii.gz'),
+                                                  add_batch_axis=True, ret_affine=True)
+        
+        os.remove(os.path.join(f'{mov_im_path}_proc.nii.gz'))
+        os.remove(os.path.join(f'{mov_im_path}_proc_field.nii.gz'))
+
+        moved = vxm.networks.Transform(moving.shape[1:-1], nb_feats=moving.shape[-1]).predict([moving, warp_to_apply[0]])
+        # save moved image
+        # vxm.py.utils.save_volfile(moved.squeeze(), os.path.join(f'{mov_im_path}_proc_reg_to_{fx_contrast}.nii.gz'), fixed.affine)
+
+    moved_data = moved.squeeze()
+    moved_nii = nib.Nifti1Image(moved_data, fixed.affine)
+    moved_in_original_space = resample_img(moved_nii, target_affine=moving_nii.affine,
+                                           target_shape=moving_nii.get_fdata().shape, interpolation='continuous')
+
+    nib.save(moved_in_original_space, moved_path)
+
+    # nib.save(moved, os.path.join(res_dir, f'{out_im_path}.nii.gz'))
+    # nib.save(warp, os.path.join(res_dir, f'{out_field_path}.nii.gz'))
 
 
 if __name__ == "__main__":
@@ -90,4 +372,21 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    run_main(args.model_path, args.fx_img_path, args.mov_img_path, args.res_dir, args.out_img_name, args.def_field_name)
+    # ***************************************************************************************
+    # TODO - Add a config file where the parameters are specified
+    # import json
+    # with open(args.config_path) as config_file:
+    #     data = json.load(config_file)
+
+    data = dict(
+        use_subvol=True,
+        subvol_size=[160, 160, 192],
+        int_steps=5,
+        int_res=2,
+        svf_res=2,
+        enc=[256, 256, 256, 256],
+        dec=[256, 256, 256, 256, 256, 256]
+    )
+    # ***************************************************************************************
+
+    run_main(data, args.model_path, args.fx_img_path, args.mov_img_path, args.res_dir, args.out_img_name, args.def_field_name)

--- a/3d_reg.py
+++ b/3d_reg.py
@@ -159,7 +159,14 @@ def preprocess(data, im_nii, mov_im_nii):
 
         # Determine how many subvolumes have to be created
         shape_in_vol = fx_img_res111.shape
-        min_perc = 0.1
+        min_perc = data['min_perc_overlap']
+        if min_perc >= 1:
+            if min_perc/100 < 1:
+                min_perc = min_perc/100
+            else:
+                min_perc = 0.1
+        elif min_perc <= 0:
+            min_perc = 0.1
 
         nb_sub_x_axis = int(shape_in_vol[0] / (in_shape[0] - min_perc * in_shape[0])) + 1
         nb_sub_y_axis = int(shape_in_vol[1] / (in_shape[1] - min_perc * in_shape[1])) + 1
@@ -396,6 +403,7 @@ if __name__ == "__main__":
     data = dict(
         use_subvol=True,
         subvol_size=[160, 160, 192],
+        min_perc_overlap=0.1,
         int_steps=5,
         int_res=2,
         svf_res=2,

--- a/3d_reg.py
+++ b/3d_reg.py
@@ -6,6 +6,7 @@ It includes a preprocessing step to scale the volumes and set it to an isotropic
 import os
 import argparse
 
+import json
 import numpy as np
 import nibabel as nib
 import voxelmorph as vxm
@@ -383,6 +384,8 @@ if __name__ == "__main__":
 
     # parameters to be specified by the user
     parser.add_argument('--model-path', required=True, type=str, help='path to the registration model')
+    parser.add_argument('--config-path', required=True, type=str,
+                        help='path to the config file with the inference model specificities')
 
     parser.add_argument('--fx-img-path', required=True, help='path to the fixed image')
     parser.add_argument('--mov-img-path', required=True, help='path to the moving image')
@@ -396,22 +399,8 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    # ***************************************************************************************
-    # TODO - Add a config file where the parameters are specified
-    # import json
-    # with open(args.config_path) as config_file:
-    #     model_inference_specs = json.load(config_file)
+    with open(args.config_path) as config_file:
+        model_inference_specs = json.load(config_file)
 
-    model_inference_specs = dict(
-        use_subvol=True,
-        subvol_size=[160, 160, 192],
-        min_perc_overlap=0.1,
-        int_steps=5,
-        int_res=2,
-        svf_res=2,
-        enc=[256, 256, 256, 256],
-        dec=[256, 256, 256, 256, 256, 256]
-    )
-    # ***************************************************************************************
-
-    run_main(model_inference_specs, args.model_path, args.fx_img_path, args.mov_img_path, args.res_dir, args.out_img_name, args.def_field_name)
+    run_main(model_inference_specs, args.model_path, args.fx_img_path,
+             args.mov_img_path, args.res_dir, args.out_img_name, args.def_field_name)

--- a/3d_reg.py
+++ b/3d_reg.py
@@ -11,7 +11,6 @@ import nibabel as nib
 import voxelmorph as vxm
 
 from nilearn.image import resample_img
-from scipy.ndimage import zoom
 from nibabel.processing import resample_from_to
 
 
@@ -270,9 +269,6 @@ def run_main(data, model_path, fx_im_path, mov_im_path, res_dir='res',
     fixed, moving, lst_subvol_fx, lst_subvol_mov, lst_coords_subvol = \
         preprocess(data, fixed_nii, moving_nii)
 
-    # nib.save(fixed, os.path.join(f'{fx_im_path}_proc.nii.gz'))
-    # nib.save(moving, os.path.join(f'{mov_im_path}_proc.nii.gz'))
-
     if data['use_subvol']:
         model_in_shape = (int(np.ceil(data['subvol_size'][0] // 16)) * 16, int(np.ceil(data['subvol_size'][1] // 16)) * 16,
                           int(np.ceil(data['subvol_size'][2] // 16)) * 16)
@@ -294,17 +290,24 @@ def run_main(data, model_path, fx_im_path, mov_im_path, res_dir='res',
         moved, warp = model.predict([np.expand_dims(moving.get_fdata().squeeze(), axis=(0, -1)),
                                      np.expand_dims(fixed.get_fdata().squeeze(), axis=(0, -1))])
         warp_data = warp[0, ...]
+
         is_warp_half_res = False if warp_data.shape[0] == model_in_shape[0] else True
         if is_warp_half_res:
-            warp_data = zoom(warp_data, (2, 2, 2, 1))
-        warp = nib.Nifti1Image(warp_data, fixed.affine)
-        # moved_nii = nib.Nifti1Image(moved[0, ..., 0], fixed.affine)
-        # nib.save(moved_nii, os.path.join(f'{mov_im_path}_proc_reg_to_{fx_contrast}.nii.gz'))
-        # nib.save(warp, os.path.join(f'{mov_im_path}_proc_field_to_{fx_contrast}.nii.gz'))
+            warp_affine = np.copy(fixed.affine)
+            for i in range(3):
+                warp_affine[i, i] = warp_affine[i, i] * 2
+            warp = nib.Nifti1Image(warp_data, warp_affine)
+            warp = resample_nib(warp, new_size=[2, 2, 2, 1], new_size_type='factor', image_dest=None,
+                                interpolation='linear', mode='constant')
+        else:
+            warp = nib.Nifti1Image(warp_data, fixed.affine)
+
         warp_in_original_space = resample_img(warp, target_affine=moving_nii.affine,
                                               target_shape=moving_nii.get_fdata().shape, interpolation='continuous')
         nib.save(warp_in_original_space, warp_path)
+
     else:
+        
         warp_field_lst = []
         for fx_subvol, mov_subvol in zip(lst_subvol_fx, lst_subvol_mov):
             _, warp = model.predict([np.expand_dims(mov_subvol.squeeze(), axis=(0, -1)),
@@ -314,15 +317,32 @@ def run_main(data, model_path, fx_im_path, mov_im_path, res_dir='res',
         is_warp_half_res = False if warp_field_lst[0].shape[0] == model_in_shape[0] else True
 
         if is_warp_half_res:
-            warp_field_lst_good_dim = []
-            for warp in warp_field_lst:
-                warp_field_lst_good_dim.append(zoom(warp, (2, 2, 2, 1)))
+            model_in_shape = np.array(model_in_shape)
+            moving_shape = np.array(moving.shape)
+            for i in range(3):
+                model_in_shape[i] = model_in_shape[i] // 2
+                moving_shape[i] = moving_shape[i] // 2
+            new_coords = []
+            for coord in lst_coords_subvol:
+                x_min, x_max, y_min, y_max, z_min, z_max = coord
+                x_min, x_max, y_min, y_max, z_min, z_max = x_min // 2, x_max // 2, y_min // 2, y_max // 2, z_min // 2, z_max // 2
+                new_coords.append((x_min, x_max, y_min, y_max, z_min, z_max))
+            lst_coords_subvol = new_coords
         else:
-            warp_field_lst_good_dim = warp_field_lst
+            moving_shape = moving.shape
 
-        warp_field = get_def_field_from_subvol(model_in_shape, moving.shape, lst_coords_subvol, warp_field_lst_good_dim)
+        warp_field = get_def_field_from_subvol(model_in_shape, moving_shape, lst_coords_subvol, warp_field_lst)
 
-        def_field_nii = nib.Nifti1Image(warp_field, affine=fixed.affine)
+        if is_warp_half_res:
+            warp_affine = np.copy(fixed.affine)
+            for i in range(3):
+                warp_affine[i, i] = warp_affine[i, i] * 2
+            warp = nib.Nifti1Image(warp_field, warp_affine)
+            def_field_nii = resample_nib(warp, new_size=[2, 2, 2, 1], new_size_type='factor', image_dest=None,
+                                         interpolation='spline', mode='constant')
+        else:
+            def_field_nii = nib.Nifti1Image(warp_field, affine=fixed.affine)
+
         nib.save(def_field_nii, os.path.join(f'{mov_im_path}_proc_field.nii.gz'))
         warp_in_original_space = resample_img(def_field_nii, target_affine=moving_nii.affine,
                                               target_shape=moving_nii.get_fdata().shape, interpolation='continuous')
@@ -338,8 +358,6 @@ def run_main(data, model_path, fx_im_path, mov_im_path, res_dir='res',
         os.remove(os.path.join(f'{mov_im_path}_proc_field.nii.gz'))
 
         moved = vxm.networks.Transform(moving.shape[1:-1], nb_feats=moving.shape[-1]).predict([moving, warp_to_apply[0]])
-        # save moved image
-        # vxm.py.utils.save_volfile(moved.squeeze(), os.path.join(f'{mov_im_path}_proc_reg_to_{fx_contrast}.nii.gz'), fixed.affine)
 
     moved_data = moved.squeeze()
     moved_nii = nib.Nifti1Image(moved_data, fixed.affine)
@@ -347,9 +365,6 @@ def run_main(data, model_path, fx_im_path, mov_im_path, res_dir='res',
                                            target_shape=moving_nii.get_fdata().shape, interpolation='continuous')
 
     nib.save(moved_in_original_space, moved_path)
-
-    # nib.save(moved, os.path.join(res_dir, f'{out_im_path}.nii.gz'))
-    # nib.save(warp, os.path.join(res_dir, f'{out_field_path}.nii.gz'))
 
 
 if __name__ == "__main__":

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Repository for training and using a contrast agnostic registration model based o
 
 ## Description
 
-This repository contains a file `train_synthmorph.py` allowing to easily use the SynthMorph method to train a contrast-invariant registration model from a config file (.json). Some additional files are provided to perform registration starting from volumes of any size (pre-processing step included in the registration file) and to be able to generate unregistered volumes by applying a deformation field synthesized from noise distribution.
+This repository contains a file `train_synthmorph.py` allowing to easily use the SynthMorph method to train a contrast-invariant registration model from a config file (.json). Some additional files are provided to perform registration starting from volumes of any size (pre-processing steps included in the registration file) and to be able to generate unregistered volumes by applying a deformation field synthesized from noise distribution.
 
 In addition, different pipelines (.sh shell script) are provided: `pipeline_bids_register_evaluate.sh`, `pipeline_bids_register_evaluate_opt_affine.sh`, ...
 These pipelines offer a framework for T2w volume registration to T1w volume for each subject of any dataset following the Brain Imaging Data Structure ([BIDS](https://bids.neuroimaging.io/)) convention. Evaluation tools are included in the pipeline (using different features from the Spinal Cord Toolbox ([SCT](https://spinalcordtoolbox.com/)) to assess the registration results, focusing on the spinal cord.
@@ -60,11 +60,11 @@ python train_synthmorph.py --config-path config/config.json
 
 ## Volumes registration
 
-The file `3d_reg.py` allows you to load a trained registration model and register two images together. It includes a preprocessing step to transform the volumes to the dimensions required by the model.
+The file `3d_reg.py` allows you to load a trained registration model and register two images together. It includes a preprocessing step to scale the volumes and set them to an isotropic resolution of 1 mm so they can be used by the model. Some parameters of the registration model used need to be specified in a config file, where you can also choose to do the inference directly on the whole volume (better accuracy but greater computational ressources needed) or on subvolumes of the size specified with the parameter `subvol_size`.
 
 To perform volumes registration:
 ```
-python 3d_reg.py --model-path model/model.h5 --fx-img-path data/t1 --mov-img-path data/t2
+python 3d_reg.py --model-path model/model.h5 --config-path config/config_inference.json --fx-img-path data/t1.nii.gz --mov-img-path data/t2.nii.gz
 ```
 
 You can dowload pretrained SynthMorph registration models provided on the [VoxelMorph repository](https://github.com/voxelmorph/voxelmorph) by clicking on the links below:
@@ -83,7 +83,7 @@ python gen_apply_def_field.py --im-path data/t2.nii.gz
 ## Registration & Evaluation pipeline
 
 A pipeline for T2w volume registration to T1w volume for each subject of any dataset following Brain Imaging Data Structure ([BIDS](https://bids.neuroimaging.io/)) convention is provided with the shell script `pipeline_bids_register_evaluate.sh`. 
-For each subject of the dataset, the T2w volume will be registered to the T1w volume using a registration model which name should be specified in the shell script and that should be located in the `model/` folder. This first part of the pipeline leads to the creation of 3 new files for each subject: `sub-xx_T1w_proc.nii.gz`, `sub-xx_T2w_proc.nii.gz` and `sub-xx_T2w_proc_reg_to_T1w.nii.gz`. It is done with the file `bids_registration.py`.  
+For each subject of the dataset, the T2w volume will be registered to the T1w volume using a registration model which name should be specified in the shell script and that should be located in the `model/` folder and a config file for the inference parameters that needs to be in the `config/` folder. This first part of the pipeline leads to the creation of 3 new files for each subject: `sub-xx_T1w_proc.nii.gz`, `sub-xx_T2w_proc.nii.gz` and `sub-xx_T2w_proc_reg_to_T1w.nii.gz`. It is done with the file `bids_registration.py`.  
 
 In the second part of the pipeline, these 3 files are used to compute some measurements and obtain a QC report in order to have a an idea of the registration performance. One measurement, the normalized Mutual Information is computed directly on the files obtained with the registration process (first part). It is done with the file `eval_reg_with_mi.py` and results in the file `nmi.csv` that summarises the results obtained for the different comparisons done. 
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ python train_synthmorph.py --config-path config/config.json
 
 ## Volumes registration
 
-The file `3d_reg.py` allows you to load a trained registration model and register two images together. It includes a preprocessing step to scale the volumes and set them to an isotropic resolution of 1 mm so they can be used by the model. Some parameters of the registration model used need to be specified in a config file, where you can also choose to do the inference directly on the whole volume (better accuracy but greater computational ressources needed) or on subvolumes of the size specified with the parameter `subvol_size`.
+The file `3d_reg.py` allows you to load a trained registration model and register two images together. It includes a preprocessing step to scale the volumes and set them to an isotropic resolution of 1 mm so they can be used by the model. Some parameters of the registration model used need to be specified in a config file, where you can also choose to do the inference directly on the whole volume (better accuracy but greater computational resources needed) or on subvolumes of the size specified with the parameter `subvol_size`.
 
 To perform volumes registration:
 ```

--- a/bids_registration.py
+++ b/bids_registration.py
@@ -270,8 +270,11 @@ def register(model_inference_specs, reg_model, fx_im_path, mov_im_path, fx_contr
     Save the warped image and the deformation field.
     """
 
-    fixed_nii = nib.load(f'{fx_im_path}.nii.gz')
-    moving_nii = nib.load(f'{mov_im_path}.nii.gz')
+    fixed_nii = nib.load(fx_im_path)
+    moving_nii = nib.load(mov_im_path)
+    
+    fx_im_path = fx_im_path.split(".")[0]
+    mov_im_path = mov_im_path.split(".")[0]
 
     fixed, moving, lst_subvol_fx, lst_subvol_mov, lst_coords_subvol = \
         preprocess(model_inference_specs, fixed_nii, moving_nii)

--- a/bids_registration.py
+++ b/bids_registration.py
@@ -1,6 +1,6 @@
 """
 File to load a trained registration model and register two images together.
-It includes a preprocessing step to transform the volumes to the dimensions required by the model.
+It includes a preprocessing step to scale the volumes and set it to an isotropic resolution of 1mm as required by the model.
 The images will be processed (and saved as im_name_proc) to be used in the registration model and then registered.
 The registered image is saved (as im_name_proc_reg_to_CONTRAST). The deformation field is also saved.
 This file can be used in a batch script to register the data of interest from all subjects in a dataset organized
@@ -17,19 +17,26 @@ import nibabel as nib
 import voxelmorph as vxm
 
 from nilearn.image import resample_img
+from scipy.ndimage import zoom
 
 
-def preprocess(im_nii, mov_im_nii, in_shape=(160, 160, 192)):
-    ''' Resize and normalize image. '''
+def preprocess(data, im_nii, mov_im_nii):
+    """
+    Scale volumes and set the voxel size to 1mm x 1mm x 1mm
+    If use subvolumes then create the subvolumes of the correct shape.
+    Return the preprocessed volumes (scaling, isotropic resolution of 1mm) as well as the
+    list of subvolumes for the fixed image, list of subvolumes for moving image and the coordinates of the subvolumes.
+    """
 
     # Scale the data between 0 and 1
-    img = im_nii.get_fdata()
-    scaled_img = (img - np.min(img)) / (np.max(img) - np.min(img))
-    scaled_nii = nib.Nifti1Image(scaled_img, im_nii.affine)
+    fx_img = im_nii.get_fdata()
+    scaled_fx_img = (fx_img - np.min(fx_img)) / (np.max(fx_img) - np.min(fx_img))
 
-    # sampling strategy: https://www.kaggle.com/mechaman/resizing-reshaping-and-resampling-nifti-files
-    # the brain images are mapped to the specified target shape at 1 mm isotropic resolution
-    target_shape = np.array(in_shape)
+    mov_img = mov_im_nii.get_fdata()
+    scaled_mov_img = (mov_img - np.min(mov_img)) / (np.max(mov_img) - np.min(mov_img))
+    
+    # Change the resolution to isotropic 1 mm resolution
+    target_shape = np.array(scaled_fx_img.shape)
     new_resolution = [1, 1, 1]
     new_affine = np.zeros((4, 4))
     new_affine[:3, :3] = np.diag(new_resolution)
@@ -37,49 +44,208 @@ def preprocess(im_nii, mov_im_nii, in_shape=(160, 160, 192)):
     new_affine[:3, 3] = target_shape*new_resolution/2.*-1
     new_affine[3, 3] = 1.
 
-    # Resample the 3d image to be in the dimension expected by the registration model
-    resampled_nii = resample_img(scaled_nii, target_affine=new_affine,
-                                 target_shape=target_shape, interpolation='continuous')
+    # Resample the to obtain the resolution wanted
+    fx_resampled_nii = resample_img(nib.Nifti1Image(scaled_fx_img, im_nii.affine),
+                                    target_affine=new_affine, interpolation='continuous')
+    fx_img_res111 = fx_resampled_nii.get_fdata()
+    mov_resampled_nii = resample_img(nib.Nifti1Image(scaled_mov_img, mov_im_nii.affine),
+                                     target_affine=new_affine, interpolation='continuous')
+    mov_img_res111 = mov_resampled_nii.get_fdata()
 
-    # Scale the data between 0 and 1
-    mov_img = mov_im_nii.get_fdata()
-    scaled_mov_img = (mov_img - np.min(mov_img)) / (np.max(mov_img) - np.min(mov_img))
-    scaled_nii = nib.Nifti1Image(scaled_mov_img, mov_im_nii.affine)
+    fx_img_shape = fx_img_res111.shape
+    mov_img_shape = mov_img_res111.shape
 
-    # Resample the 3d image to be in the dimension expected by the registration model
-    mov_resampled_nii = resample_img(scaled_nii, target_affine=new_affine,
-                                     target_shape=target_shape, interpolation='continuous')
+    max_img_shape = max(fx_img_shape, mov_img_shape)
+    # Ensure that the volumes can be used in the registration model
+    new_img_shape = (int(np.ceil(max_img_shape[0] // 16)) * 16, int(np.ceil(max_img_shape[1] // 16)) * 16,
+                     int(np.ceil(max_img_shape[2] // 16)) * 16)
 
-    return resampled_nii, mov_resampled_nii
+    # Pad the volumes to the max shape
+    fx_img_pad_nii = resample_img(fx_resampled_nii, target_affine=new_affine,
+                                  target_shape=new_img_shape, interpolation='continuous')
+    fx_img_pad = fx_img_pad_nii.get_fdata()
+    mov_img_pad_nii = resample_img(mov_resampled_nii, target_affine=new_affine,
+                                   target_shape=new_img_shape, interpolation='continuous')
+    mov_img_pad = mov_img_pad_nii.get_fdata()
+
+    if data['use_subvol']:
+
+        in_shape = (int(np.ceil(data['subvol_size'][0] // 16)) * 16, int(np.ceil(data['subvol_size'][1] // 16)) * 16,
+                    int(np.ceil(data['subvol_size'][2] // 16)) * 16)
+
+        # Determine how many subvolumes have to be created
+        shape_in_vol = fx_img_pad.shape
+        min_perc = 0.1
+
+        nb_sub_x_axis = int(shape_in_vol[0] / (in_shape[0] - min_perc * in_shape[0])) + 1
+        nb_sub_y_axis = int(shape_in_vol[1] / (in_shape[1] - min_perc * in_shape[1])) + 1
+        nb_sub_z_axis = int(shape_in_vol[2] / (in_shape[2] - min_perc * in_shape[2])) + 1
+
+        # Determine the number of overlapping voxels for each axis
+        x_vox_overlap, y_vox_overlap, z_vox_overlap = 0, 0, 0
+        if nb_sub_x_axis > 1:
+            x_vox_overlap = (in_shape[0] - (shape_in_vol[0]/nb_sub_x_axis)) * (nb_sub_x_axis/(nb_sub_x_axis - 1))
+        if nb_sub_y_axis > 1:
+            y_vox_overlap = (in_shape[1] - (shape_in_vol[1]/nb_sub_y_axis)) * (nb_sub_y_axis/(nb_sub_y_axis - 1))
+        if nb_sub_z_axis > 1:
+            z_vox_overlap = (in_shape[2] - (shape_in_vol[2]/nb_sub_z_axis)) * (nb_sub_z_axis/(nb_sub_z_axis - 1))
+
+        # Get the subvolumes and the coordinates of the x_min, x_max, y_min, y_max, z_min, z_max
+        lst_subvol_fx = []
+        lst_subvol_mov = []
+        lst_coords_subvol = []
+
+        x_max, y_max, z_max = 0, 0, 0
+        for i in range(nb_sub_x_axis):
+            x_min = 0 if i == 0 else int(x_max - x_vox_overlap)
+            x_max = int(x_min + in_shape[0])
+            for j in range(nb_sub_y_axis):
+                y_min = 0 if j == 0 else int(y_max - y_vox_overlap)
+                y_max = int(y_min + in_shape[1])
+                for k in range(nb_sub_z_axis):
+                    z_min = 0 if k == 0 else int(z_max - z_vox_overlap)
+                    z_max = int(z_min + in_shape[2])
+                    subvol_fx = fx_img_pad[x_min:x_max, y_min:y_max, z_min:z_max]
+                    subvol_mov = mov_img_pad[x_min:x_max, y_min:y_max, z_min:z_max]
+
+                    lst_subvol_fx.append(subvol_fx)
+                    lst_subvol_mov.append(subvol_mov)
+                    lst_coords_subvol.append((x_min, x_max, y_min, y_max, z_min, z_max))
+    else:
+        lst_subvol_fx, lst_subvol_mov, lst_coords_subvol = [], [], []
+
+    # Create nifti files with the preprocessed volumes
+    fx_preproc_nii = nib.Nifti1Image(fx_img_pad, new_affine)
+    mov_preproc_nii = nib.Nifti1Image(mov_img_pad, new_affine)
+
+    return fx_preproc_nii, mov_preproc_nii, lst_subvol_fx, lst_subvol_mov, lst_coords_subvol
 
 
-def register(reg_model, fx_im_path, mov_im_path, fx_contrast='T1w'):
+def register(data, reg_model, fx_im_path, mov_im_path, fx_contrast='T1w'):
     """
     Preprocess the two images and register the moving image to the fixed one using the provided model.
     Save the warped image and the deformation field.
     """
 
-    model_in_shape = reg_model.inputs[0].shape[1:-1]
-
     fixed_nii = nib.load(f'{fx_im_path}.nii.gz')
     moving_nii = nib.load(f'{mov_im_path}.nii.gz')
 
-    fixed, moving = preprocess(fixed_nii, moving_nii, model_in_shape)
+    fixed, moving, lst_subvol_fx, lst_subvol_mov, lst_coords_subvol = \
+        preprocess(data, fixed_nii, moving_nii)
 
     nib.save(fixed, os.path.join(f'{fx_im_path}_proc.nii.gz'))
     nib.save(moving, os.path.join(f'{mov_im_path}_proc.nii.gz'))
 
-    moved, warp = reg_model.predict([np.expand_dims(moving.get_fdata().squeeze(), axis=(0, -1)),
+    if data['use_subvol']:
+        model_in_shape = (int(np.ceil(data['subvol_size'][0] // 16)) * 16, int(np.ceil(data['subvol_size'][1] // 16)) * 16,
+                          int(np.ceil(data['subvol_size'][2] // 16)) * 16)
+    else:
+        model_in_shape = fixed.get_fdata().shape
+
+    reg_args = dict(
+        inshape=model_in_shape,
+        int_steps=data['int_steps'],
+        int_resolution=data['int_res'],
+        svf_resolution=data['svf_res'],
+        nb_unet_features=(data['enc'], data['dec'])
+    )
+
+    model = vxm.networks.VxmDense(**reg_args)
+    model.set_weights(reg_model.get_weights())
+
+    if not data['use_subvol']:
+        moved, warp = model.predict([np.expand_dims(moving.get_fdata().squeeze(), axis=(0, -1)),
                                      np.expand_dims(fixed.get_fdata().squeeze(), axis=(0, -1))])
+        warp_data = warp[0, ...]
+        is_warp_half_res = False if warp_data.shape[0] == model_in_shape[0] else True
+        if is_warp_half_res:
+            warp_data = zoom(warp_data, (2, 2, 2, 1))
+        warp = nib.Nifti1Image(warp_data, fixed.affine)
+        moved_nii = nib.Nifti1Image(moved[0, ..., 0], fixed.affine)
+        nib.save(moved_nii, os.path.join(f'{mov_im_path}_proc_reg_to_{fx_contrast}.nii.gz'))
+        nib.save(warp, os.path.join(f'{mov_im_path}_proc_field_to_{fx_contrast}.nii.gz'))
+        warp_in_original_space = resample_img(warp, target_affine=moving_nii.affine,
+                                              target_shape=moving_nii.get_fdata().shape, interpolation='continuous')
+        nib.save(warp_in_original_space, os.path.join(f'{mov_im_path}_warp_original_dim.nii.gz'))
+    else:
+        warp_field_lst = []
+        for fx_subvol, mov_subvol in zip(lst_subvol_fx, lst_subvol_mov):
+            _, warp = model.predict([np.expand_dims(mov_subvol.squeeze(), axis=(0, -1)),
+                                     np.expand_dims(fx_subvol.squeeze(), axis=(0, -1))])
+            warp_field_lst.append(warp[0, ...])
 
-    moved = nib.Nifti1Image(moved[0, ..., 0], fixed.affine)
-    warp = nib.Nifti1Image(warp[0, ...], fixed.affine)
+        is_warp_half_res = False if warp_field_lst[0].shape[0] == model_in_shape[0] else True
 
-    nib.save(moved, os.path.join(f'{mov_im_path}_proc_reg_to_{fx_contrast}.nii.gz'))
-    nib.save(warp, os.path.join(f'{mov_im_path}_proc_field_to_{fx_contrast}.nii.gz'))
+        if is_warp_half_res:
+            warp_field_lst_good_dim = []
+            for warp in warp_field_lst:
+                warp_field_lst_good_dim.append(zoom(warp, (2, 2, 2, 1)))
+        else:
+            warp_field_lst_good_dim = warp_field_lst
+
+        # Create a map of weights that will be applied on the different warping fields to reduce the boundaries effect
+        # via a weighted average of the overlapping volumes (between the volumes) giving more weights to the inside part
+        x, y, z = model_in_shape[0]//2, model_in_shape[1]//2, model_in_shape[2]//2
+        grid = np.mgrid[-x:x, -y:y, -z:z]
+        w_map = np.maximum(np.abs(grid[0]), np.abs(grid[1]))
+        w_map = np.maximum(w_map, np.abs(grid[2]))
+        # The center of the volume has a weight of 1 and then it decreases linearly towards the boundaries
+        w_map = 1 - w_map/(np.max(w_map) + 1)
+
+        # Get the map representing the weights of all the subvolumes and place the map to the correct location of each
+        # subvolume
+        sum_weights = np.zeros((moving.shape[0], moving.shape[1], moving.shape[2]))
+        w_map_subvol_lst = []
+        warp_subvol_lst = []
+        for coords, warp in zip(lst_coords_subvol, warp_field_lst_good_dim):
+            w_map_subvol = np.zeros((moving.shape[0], moving.shape[1], moving.shape[2]))
+            warp_field_tmp = np.zeros((moving.shape[0], moving.shape[1], moving.shape[2], 3))
+            x_min, x_max, y_min, y_max, z_min, z_max = coords
+            sum_weights[x_min:x_max, y_min:y_max, z_min:z_max] += w_map
+            w_map_subvol[x_min:x_max, y_min:y_max, z_min:z_max] = w_map
+            warp_field_tmp[x_min:x_max, y_min:y_max, z_min:z_max, :] = warp
+            w_map_subvol_lst.append(w_map_subvol)
+            warp_subvol_lst.append(warp_field_tmp)
+
+        # To avoid division by 0, replace the sum weights that are 0 by 1 before the division (may appear for the voxels
+        # at the border of the original volume if the size of this latter is even on certain axes)
+        sum_weights[sum_weights == 0] = 1
+
+        # Divide the weight map of each subvolume by the sum of all the weights of the different subvolumes to determine
+        # the relative weight of each subvolume in the prediction of the final displacement vector
+        w_map_subvol_final_lst = []
+        for w_map_subvol in w_map_subvol_lst:
+            w_map_subvol_final_lst.append(w_map_subvol/sum_weights)
+
+        # Reconstruct the warping field
+        warp_field = np.zeros((moving.shape[0], moving.shape[1], moving.shape[2], 3))
+        for w_subvol, warp in zip(w_map_subvol_final_lst, warp_subvol_lst):
+            for i in range(3):
+                warp_field[..., i] += w_subvol * warp[..., i]
+
+        def_field_nii = nib.Nifti1Image(warp_field, affine=fixed.affine)
+        nib.save(def_field_nii, os.path.join(f'{mov_im_path}_proc_field_to_{fx_contrast}.nii.gz'))
+        warp_in_original_space = resample_img(def_field_nii, target_affine=moving_nii.affine,
+                                              target_shape=moving_nii.get_fdata().shape, interpolation='continuous')
+        nib.save(warp_in_original_space, os.path.join(f'{mov_im_path}_warp_original_dim.nii.gz'))
+
+        moving = vxm.py.utils.load_volfile(os.path.join(f'{mov_im_path}_proc.nii.gz'),
+                                           add_batch_axis=True, add_feat_axis=True)
+        warp_to_apply = vxm.py.utils.load_volfile(os.path.join(f'{mov_im_path}_proc_field_to_{fx_contrast}.nii.gz'),
+                                                  add_batch_axis=True, ret_affine=True)
+
+        moved = vxm.networks.Transform(moving.shape[1:-1], nb_feats=moving.shape[-1]).predict([moving, warp_to_apply[0]])
+        # save moved image
+        vxm.py.utils.save_volfile(moved.squeeze(), os.path.join(f'{mov_im_path}_proc_reg_to_{fx_contrast}.nii.gz'), fixed.affine)
+
+    moved_data = moved.squeeze()
+    moved_nii = nib.Nifti1Image(moved_data, fixed.affine)
+    moved_in_original_space = resample_img(moved_nii, target_affine=moving_nii.affine,
+                                           target_shape=moving_nii.get_fdata().shape, interpolation='continuous')
+    nib.save(moved_in_original_space, os.path.join(f'{mov_im_path}_reg_original_dim.nii.gz'))
 
 
-def run_main(reg_model_path, fx_im_path, mov_im_path, fx_im_contrast='T1w'):
+def run_main(data, reg_model_path, fx_im_path, mov_im_path, fx_im_contrast='T1w'):
     """
     Load the registration model
     Preprocess the fixed and moving images
@@ -88,7 +254,7 @@ def run_main(reg_model_path, fx_im_path, mov_im_path, fx_im_contrast='T1w'):
     # Load the registration model
     model = vxm.networks.VxmDense.load(reg_model_path, input_model=None)
 
-    register(model, fx_im_path, mov_im_path, fx_contrast=fx_im_contrast)
+    register(data, model, fx_im_path, mov_im_path, fx_contrast=fx_im_contrast)
 
 
 if __name__ == "__main__":
@@ -111,9 +277,26 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
+    # ***************************************************************************************
+    # TODO - Add a config file where the parameters are specified
+    # import json
+    # with open(args.config_path) as config_file:
+    #     data = json.load(config_file)
+
+    data = dict(
+        use_subvol=True,
+        subvol_size=[160, 160, 192],
+        int_steps=5,
+        int_res=2,
+        svf_res=2,
+        enc=[256, 256, 256, 256],
+        dec=[256, 256, 256, 256, 256, 256]
+    )
+    # ***************************************************************************************
+
     if eval(args.one_cpu_tf):
         # set that TF can use only one CPU
         session_conf = tf.compat.v1.ConfigProto(intra_op_parallelism_threads=1, inter_op_parallelism_threads=1)
         sess = tf.compat.v1.Session(config=session_conf)
 
-    run_main(args.model_path, args.fx_img_path, args.mov_img_path, args.fx_img_contrast)
+    run_main(data, args.model_path, args.fx_img_path, args.mov_img_path, args.fx_img_contrast)

--- a/bids_registration.py
+++ b/bids_registration.py
@@ -121,7 +121,7 @@ def resample_nib(image, new_size=None, new_size_type=None, image_dest=None, inte
     return img_r
 
 
-def preprocess(data, im_nii, mov_im_nii):
+def preprocess(model_inference_specs, im_nii, mov_im_nii):
     """
     Scale volumes and create subvolumes of the correct shape.
     Return the preprocessed volumes (scaling, zero-padding, isotropic resolution of 1mm) as well as the
@@ -158,14 +158,15 @@ def preprocess(data, im_nii, mov_im_nii):
                                      target_shape=new_img_shape, interpolation='continuous')
     mov_img_res111 = mov_resampled_nii.get_fdata()
 
-    if data['use_subvol']:
+    if model_inference_specs['use_subvol']:
 
-        in_shape = (int(np.ceil(data['subvol_size'][0] // 16)) * 16, int(np.ceil(data['subvol_size'][1] // 16)) * 16,
-                    int(np.ceil(data['subvol_size'][2] // 16)) * 16)
+        in_shape = (int(np.ceil(model_inference_specs['subvol_size'][0] // 16)) * 16, 
+                    int(np.ceil(model_inference_specs['subvol_size'][1] // 16)) * 16,
+                    int(np.ceil(model_inference_specs['subvol_size'][2] // 16)) * 16)
 
         # Determine how many subvolumes have to be created
         shape_in_vol = fx_img_res111.shape
-        min_perc = data['min_perc_overlap']
+        min_perc = model_inference_specs['min_perc_overlap']
         if min_perc >= 1:
             if min_perc/100 < 1:
                 min_perc = min_perc/100
@@ -262,7 +263,7 @@ def get_def_field_from_subvol(model_in_shape, im_shape, lst_coords_subvol, lst_w
     return warp_field
 
 
-def register(data, reg_model, fx_im_path, mov_im_path, fx_contrast='T1w'):
+def register(model_inference_specs, reg_model, fx_im_path, mov_im_path, fx_contrast='T1w'):
     """
     Preprocess the two images and register the moving image to the fixed one using the provided model.
     Save the warped image and the deformation field.
@@ -272,29 +273,30 @@ def register(data, reg_model, fx_im_path, mov_im_path, fx_contrast='T1w'):
     moving_nii = nib.load(f'{mov_im_path}.nii.gz')
 
     fixed, moving, lst_subvol_fx, lst_subvol_mov, lst_coords_subvol = \
-        preprocess(data, fixed_nii, moving_nii)
+        preprocess(model_inference_specs, fixed_nii, moving_nii)
 
     nib.save(fixed, os.path.join(f'{fx_im_path}_proc.nii.gz'))
     nib.save(moving, os.path.join(f'{mov_im_path}_proc.nii.gz'))
 
-    if data['use_subvol']:
-        model_in_shape = (int(np.ceil(data['subvol_size'][0] // 16)) * 16, int(np.ceil(data['subvol_size'][1] // 16)) * 16,
-                          int(np.ceil(data['subvol_size'][2] // 16)) * 16)
+    if model_inference_specs['use_subvol']:
+        model_in_shape = (int(np.ceil(model_inference_specs['subvol_size'][0] // 16)) * 16, 
+                          int(np.ceil(model_inference_specs['subvol_size'][1] // 16)) * 16,
+                          int(np.ceil(model_inference_specs['subvol_size'][2] // 16)) * 16)
     else:
         model_in_shape = fixed.get_fdata().shape
 
     reg_args = dict(
         inshape=model_in_shape,
-        int_steps=data['int_steps'],
-        int_resolution=data['int_res'],
-        svf_resolution=data['svf_res'],
-        nb_unet_features=(data['enc'], data['dec'])
+        int_steps=model_inference_specs['int_steps'],
+        int_resolution=model_inference_specs['int_res'],
+        svf_resolution=model_inference_specs['svf_res'],
+        nb_unet_features=(model_inference_specs['enc'], model_inference_specs['dec'])
     )
 
     model = vxm.networks.VxmDense(**reg_args)
     model.set_weights(reg_model.get_weights())
 
-    if not data['use_subvol']:
+    if not model_inference_specs['use_subvol']:
         moved, warp = model.predict([np.expand_dims(moving.get_fdata().squeeze(), axis=(0, -1)),
                                      np.expand_dims(fixed.get_fdata().squeeze(), axis=(0, -1))])
         warp_data = warp[0, ...]
@@ -374,7 +376,7 @@ def register(data, reg_model, fx_im_path, mov_im_path, fx_contrast='T1w'):
     nib.save(moved_in_original_space, os.path.join(f'{mov_im_path}_reg_original_dim.nii.gz'))
 
 
-def run_main(data, reg_model_path, fx_im_path, mov_im_path, fx_im_contrast='T1w'):
+def run_main(model_inference_specs, reg_model_path, fx_im_path, mov_im_path, fx_im_contrast='T1w'):
     """
     Load the registration model
     Preprocess the fixed and moving images
@@ -383,7 +385,7 @@ def run_main(data, reg_model_path, fx_im_path, mov_im_path, fx_im_contrast='T1w'
     # Load the registration model
     model = vxm.networks.VxmDense.load(reg_model_path, input_model=None)
 
-    register(data, model, fx_im_path, mov_im_path, fx_contrast=fx_im_contrast)
+    register(model_inference_specs, model, fx_im_path, mov_im_path, fx_contrast=fx_im_contrast)
 
 
 if __name__ == "__main__":
@@ -410,9 +412,9 @@ if __name__ == "__main__":
     # TODO - Add a config file where the parameters are specified
     # import json
     # with open(args.config_path) as config_file:
-    #     data = json.load(config_file)
+    #     model_inference_specs = json.load(config_file)
 
-    data = dict(
+    model_inference_specs = dict(
         use_subvol=True,
         subvol_size=[160, 160, 192],
         min_perc_overlap=0.1,
@@ -429,4 +431,4 @@ if __name__ == "__main__":
         session_conf = tf.compat.v1.ConfigProto(intra_op_parallelism_threads=1, inter_op_parallelism_threads=1)
         sess = tf.compat.v1.Session(config=session_conf)
 
-    run_main(data, args.model_path, args.fx_img_path, args.mov_img_path, args.fx_img_contrast)
+    run_main(model_inference_specs, args.model_path, args.fx_img_path, args.mov_img_path, args.fx_img_contrast)

--- a/bids_registration.py
+++ b/bids_registration.py
@@ -11,6 +11,7 @@ The contrast of the fixed image can be specified as argument for the files namin
 import os
 import argparse
 
+import json
 import numpy as np
 import tensorflow as tf
 import nibabel as nib
@@ -395,6 +396,8 @@ if __name__ == "__main__":
 
     # parameters to be specified by the user
     parser.add_argument('--model-path', required=True, type=str, help='path to the registration model')
+    parser.add_argument('--config-path', required=True, type=str,
+                        help='path to the config file with the inference model specificities')
 
     parser.add_argument('--fx-img-path', required=True, help='path to the fixed image')
     parser.add_argument('--mov-img-path', required=True, help='path to the moving image')
@@ -408,23 +411,8 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    # ***************************************************************************************
-    # TODO - Add a config file where the parameters are specified
-    # import json
-    # with open(args.config_path) as config_file:
-    #     model_inference_specs = json.load(config_file)
-
-    model_inference_specs = dict(
-        use_subvol=True,
-        subvol_size=[160, 160, 192],
-        min_perc_overlap=0.1,
-        int_steps=5,
-        int_res=2,
-        svf_res=2,
-        enc=[256, 256, 256, 256],
-        dec=[256, 256, 256, 256, 256, 256]
-    )
-    # ***************************************************************************************
+    with open(args.config_path) as config_file:
+        model_inference_specs = json.load(config_file)
 
     if eval(args.one_cpu_tf):
         # set that TF can use only one CPU

--- a/bids_registration.py
+++ b/bids_registration.py
@@ -18,13 +18,114 @@ import voxelmorph as vxm
 
 from nilearn.image import resample_img
 from scipy.ndimage import zoom
+from nibabel.processing import resample_from_to
+
+
+def resample_nib(image, new_size=None, new_size_type=None, image_dest=None, interpolation='linear', mode='nearest'):
+    """
+    Resample a nibabel or Image object based on a specified resampling factor.
+    Can deal with 2d, 3d or 4d image objects.
+    Copyright (c) 2014 Polytechnique Montreal <www.neuro.polymtl.ca>
+    Authors: Julien Cohen-Adad, Sara Dupont
+
+    :param image: nibabel or Image image.
+    :param new_size: list of float: Resampling factor, final dimension or resolution, depending on new_size_type.
+    :param new_size_type: {'vox', 'factor', 'mm'}: Feature used for resampling. Examples:
+        new_size=[128, 128, 90], new_size_type='vox' --> Resampling to a dimension of 128x128x90 voxels
+        new_size=[2, 2, 2], new_size_type='factor' --> 2x isotropic upsampling
+        new_size=[1, 1, 5], new_size_type='mm' --> Resampling to a resolution of 1x1x5 mm
+    :param image_dest: Destination image to resample the input image to. In this case, new_size and new_size_type
+        are ignored
+    :param interpolation: {'nn', 'linear', 'spline'}. The interpolation type
+    :param mode: Outside values are filled with 0 ('constant') or nearest value ('nearest').
+    :return: The resampled nibabel or Image image (depending on the input object type).
+    """
+
+    # set interpolation method
+    dict_interp = {'nn': 0, 'linear': 1, 'spline': 2}
+
+    # If input is an Image object, create nibabel object from it
+    if type(image) == nib.nifti1.Nifti1Image:
+        img = image
+    else:
+        raise Exception(TypeError)
+
+    if image_dest is None:
+        # Get dimensions of data
+        p = img.header.get_zooms()
+        shape = img.header.get_data_shape()
+
+        if img.ndim == 4:
+            new_size += ['1']  # needed because the code below is general, i.e., does not assume 3d input and uses img.shape
+
+        # compute new shape based on specific resampling method
+        if new_size_type == 'vox':
+            shape_r = tuple([int(new_size[i]) for i in range(img.ndim)])
+        elif new_size_type == 'factor':
+            if len(new_size) == 1:
+                # isotropic resampling
+                new_size = tuple([new_size[0] for i in range(img.ndim)])
+            # compute new shape as: shape_r = shape * f
+            shape_r = tuple([int(np.round(shape[i] * float(new_size[i]))) for i in range(img.ndim)])
+        elif new_size_type == 'mm':
+            if len(new_size) == 1:
+                # isotropic resampling
+                new_size = tuple([new_size[0] for i in range(img.ndim)])
+            # compute new shape as: shape_r = shape * (p_r / p)
+            shape_r = tuple([int(np.round(shape[i] * float(p[i]) / float(new_size[i]))) for i in range(img.ndim)])
+        else:
+            raise ValueError("'new_size_type' is not recognized.")
+
+        # Generate 3d affine transformation: R
+        affine = img.affine[:4, :4]
+        affine[3, :] = np.array([0, 0, 0, 1])  # satisfy to nifti convention. Otherwise it grabs the temporal
+        # logger.debug('Affine matrix: \n' + str(affine))
+        R = np.eye(4)
+        for i in range(3):
+            try:
+                R[i, i] = img.shape[i] / float(shape_r[i])
+            except ZeroDivisionError:
+                raise ZeroDivisionError("Destination size is zero for dimension {}. You are trying to resample to an "
+                                        "unrealistic dimension. Check your NIFTI pixdim values to make sure they are "
+                                        "not corrupted.".format(i))
+
+        affine_r = np.dot(affine, R)
+        reference = (shape_r, affine_r)
+
+    # If reference is provided
+    else:
+        if type(image_dest) == nib.nifti1.Nifti1Image:
+            reference = image_dest
+        else:
+            raise Exception(TypeError)
+
+    if img.ndim == 3:
+        # we use mode 'nearest' to overcome issue #2453
+        img_r = resample_from_to(img, to_vox_map=reference, order=dict_interp[interpolation],
+                                 mode=mode, cval=0.0, out_class=None)
+
+    elif img.ndim == 4:
+        # Import here instead of top of the file because this is an isolated case and nibabel takes time to import
+        data4d = np.zeros(shape_r)
+        # Loop across 4th dimension and resample each 3d volume
+        for it in range(img.shape[3]):
+            # Create dummy 3d nibabel image
+            nii_tmp = nib.nifti1.Nifti1Image(img.get_data()[..., it], affine)
+            img3d_r = resample_from_to(nii_tmp, to_vox_map=(shape_r[:-1], affine_r),
+                                       order=dict_interp[interpolation], mode=mode, cval=0.0, out_class=None)
+            data4d[..., it] = img3d_r.get_data()
+        # Create 4d nibabel Image
+        img_r = nib.nifti1.Nifti1Image(data4d, affine_r)
+        # Copy over the TR parameter from original 4D image (otherwise it will be incorrectly set to 1)
+        img_r.header.set_zooms(list(img_r.header.get_zooms()[0:3]) + [img.header.get_zooms()[3]])
+
+    return img_r
 
 
 def preprocess(data, im_nii, mov_im_nii):
     """
-    Scale volumes and set the voxel size to 1mm x 1mm x 1mm
-    If use subvolumes then create the subvolumes of the correct shape.
-    Return the preprocessed volumes (scaling, isotropic resolution of 1mm) as well as the
+    Scale volumes and create subvolumes of the correct shape.
+    Return the preprocessed volumes (scaling, zero-padding, isotropic resolution of 1mm) as well as the
     list of subvolumes for the fixed image, list of subvolumes for moving image and the coordinates of the subvolumes.
     """
 
@@ -34,39 +135,29 @@ def preprocess(data, im_nii, mov_im_nii):
 
     mov_img = mov_im_nii.get_fdata()
     scaled_mov_img = (mov_img - np.min(mov_img)) / (np.max(mov_img) - np.min(mov_img))
-    
-    # Change the resolution to isotropic 1 mm resolution
-    target_shape = np.array(scaled_fx_img.shape)
-    new_resolution = [1, 1, 1]
-    new_affine = np.zeros((4, 4))
-    new_affine[:3, :3] = np.diag(new_resolution)
-    # putting point 0,0,0 in the middle of the new volume - this could be refined in the future
-    new_affine[:3, 3] = target_shape*new_resolution/2.*-1
-    new_affine[3, 3] = 1.
 
-    # Resample the to obtain the resolution wanted
-    fx_resampled_nii = resample_img(nib.Nifti1Image(scaled_fx_img, im_nii.affine),
-                                    target_affine=new_affine, interpolation='continuous')
+    # Change the resolution to isotropic 1 mm resolution
+    fx_resampled_nii = resample_nib(nib.Nifti1Image(scaled_fx_img, im_nii.affine), new_size=[1, 1, 1],
+                                    new_size_type='mm', image_dest=None, interpolation='linear', mode='constant')
     fx_img_res111 = fx_resampled_nii.get_fdata()
-    mov_resampled_nii = resample_img(nib.Nifti1Image(scaled_mov_img, mov_im_nii.affine),
-                                     target_affine=new_affine, interpolation='continuous')
+    mov_resampled_nii = resample_nib(nib.Nifti1Image(scaled_mov_img, mov_im_nii.affine),
+                                     image_dest=fx_resampled_nii, interpolation='linear', mode='constant')
     mov_img_res111 = mov_resampled_nii.get_fdata()
 
+    # Ensure that the volumes can be used in the registration model
     fx_img_shape = fx_img_res111.shape
     mov_img_shape = mov_img_res111.shape
-
     max_img_shape = max(fx_img_shape, mov_img_shape)
-    # Ensure that the volumes can be used in the registration model
     new_img_shape = (int(np.ceil(max_img_shape[0] // 16)) * 16, int(np.ceil(max_img_shape[1] // 16)) * 16,
                      int(np.ceil(max_img_shape[2] // 16)) * 16)
 
     # Pad the volumes to the max shape
-    fx_img_pad_nii = resample_img(fx_resampled_nii, target_affine=new_affine,
-                                  target_shape=new_img_shape, interpolation='continuous')
-    fx_img_pad = fx_img_pad_nii.get_fdata()
-    mov_img_pad_nii = resample_img(mov_resampled_nii, target_affine=new_affine,
-                                   target_shape=new_img_shape, interpolation='continuous')
-    mov_img_pad = mov_img_pad_nii.get_fdata()
+    fx_resampled_nii = resample_img(fx_resampled_nii, target_affine=fx_resampled_nii.affine,
+                                    target_shape=new_img_shape, interpolation='continuous')
+    fx_img_res111 = fx_resampled_nii.get_fdata()
+    mov_resampled_nii = resample_img(mov_resampled_nii, target_affine=mov_resampled_nii.affine,
+                                     target_shape=new_img_shape, interpolation='continuous')
+    mov_img_res111 = mov_resampled_nii.get_fdata()
 
     if data['use_subvol']:
 
@@ -74,7 +165,7 @@ def preprocess(data, im_nii, mov_im_nii):
                     int(np.ceil(data['subvol_size'][2] // 16)) * 16)
 
         # Determine how many subvolumes have to be created
-        shape_in_vol = fx_img_pad.shape
+        shape_in_vol = fx_img_res111.shape
         min_perc = 0.1
 
         nb_sub_x_axis = int(shape_in_vol[0] / (in_shape[0] - min_perc * in_shape[0])) + 1
@@ -105,8 +196,8 @@ def preprocess(data, im_nii, mov_im_nii):
                 for k in range(nb_sub_z_axis):
                     z_min = 0 if k == 0 else int(z_max - z_vox_overlap)
                     z_max = int(z_min + in_shape[2])
-                    subvol_fx = fx_img_pad[x_min:x_max, y_min:y_max, z_min:z_max]
-                    subvol_mov = mov_img_pad[x_min:x_max, y_min:y_max, z_min:z_max]
+                    subvol_fx = fx_img_res111[x_min:x_max, y_min:y_max, z_min:z_max]
+                    subvol_mov = mov_img_res111[x_min:x_max, y_min:y_max, z_min:z_max]
 
                     lst_subvol_fx.append(subvol_fx)
                     lst_subvol_mov.append(subvol_mov)
@@ -114,11 +205,7 @@ def preprocess(data, im_nii, mov_im_nii):
     else:
         lst_subvol_fx, lst_subvol_mov, lst_coords_subvol = [], [], []
 
-    # Create nifti files with the preprocessed volumes
-    fx_preproc_nii = nib.Nifti1Image(fx_img_pad, new_affine)
-    mov_preproc_nii = nib.Nifti1Image(mov_img_pad, new_affine)
-
-    return fx_preproc_nii, mov_preproc_nii, lst_subvol_fx, lst_subvol_mov, lst_coords_subvol
+    return fx_resampled_nii, mov_resampled_nii, lst_subvol_fx, lst_subvol_mov, lst_coords_subvol
 
 
 def get_def_field_from_subvol(model_in_shape, im_shape, lst_coords_subvol, lst_warp_subvol):

--- a/bids_registration.py
+++ b/bids_registration.py
@@ -165,7 +165,14 @@ def preprocess(data, im_nii, mov_im_nii):
 
         # Determine how many subvolumes have to be created
         shape_in_vol = fx_img_res111.shape
-        min_perc = 0.1
+        min_perc = data['min_perc_overlap']
+        if min_perc >= 1:
+            if min_perc/100 < 1:
+                min_perc = min_perc/100
+            else:
+                min_perc = 0.1
+        elif min_perc <= 0:
+            min_perc = 0.1
 
         nb_sub_x_axis = int(shape_in_vol[0] / (in_shape[0] - min_perc * in_shape[0])) + 1
         nb_sub_y_axis = int(shape_in_vol[1] / (in_shape[1] - min_perc * in_shape[1])) + 1
@@ -311,7 +318,7 @@ def register(data, reg_model, fx_im_path, mov_im_path, fx_contrast='T1w'):
         nib.save(warp_in_original_space, os.path.join(f'{mov_im_path}_warp_original_dim.nii.gz'))
         
     else:
-        
+
         warp_field_lst = []
         for fx_subvol, mov_subvol in zip(lst_subvol_fx, lst_subvol_mov):
             _, warp = model.predict([np.expand_dims(mov_subvol.squeeze(), axis=(0, -1)),
@@ -408,6 +415,7 @@ if __name__ == "__main__":
     data = dict(
         use_subvol=True,
         subvol_size=[160, 160, 192],
+        min_perc_overlap=0.1,
         int_steps=5,
         int_res=2,
         svf_res=2,

--- a/bids_two_steps_registration.py
+++ b/bids_two_steps_registration.py
@@ -166,7 +166,14 @@ def preprocess(data, im_nii, mov_im_nii):
 
         # Determine how many subvolumes have to be created
         shape_in_vol = fx_img_res111.shape
-        min_perc = 0.1
+        min_perc = data['min_perc_overlap']
+        if min_perc >= 1:
+            if min_perc/100 < 1:
+                min_perc = min_perc/100
+            else:
+                min_perc = 0.1
+        elif min_perc <= 0:
+            min_perc = 0.1
 
         nb_sub_x_axis = int(shape_in_vol[0] / (in_shape[0] - min_perc * in_shape[0])) + 1
         nb_sub_y_axis = int(shape_in_vol[1] / (in_shape[1] - min_perc * in_shape[1])) + 1
@@ -477,6 +484,7 @@ if __name__ == "__main__":
     data = dict(
         use_subvol=True,
         subvol_size=[160, 160, 192],
+        min_perc_overlap=0.1,
         int_steps=5,
         int_res=2,
         svf_res=2,

--- a/bids_two_steps_registration.py
+++ b/bids_two_steps_registration.py
@@ -18,7 +18,6 @@ import nibabel as nib
 import voxelmorph as vxm
 
 from nilearn.image import resample_img
-from scipy.ndimage import zoom
 from nibabel.processing import resample_from_to
 
 
@@ -300,17 +299,27 @@ def register(data, reg_model1, reg_model2, fx_im_path, mov_im_path, fx_contrast=
 
         warp = vxm.utils.compose([K.constant(warp_first_reg[0, ...]), K.constant(warp_second_reg[0, ...])])
         warp_data = K.eval(warp)
+
         is_warp_half_res = False if warp_data.shape[0] == model_in_shape[0] else True
         if is_warp_half_res:
-            warp_data = zoom(warp_data, (2, 2, 2, 1))
-        warp = nib.Nifti1Image(warp_data, fixed.affine)
+            warp_affine = np.copy(fixed.affine)
+            for i in range(3):
+                warp_affine[i, i] = warp_affine[i, i] * 2
+            warp = nib.Nifti1Image(warp_data, warp_affine)
+            warp = resample_nib(warp, new_size=[2, 2, 2, 1], new_size_type='factor', image_dest=None,
+                                interpolation='linear', mode='constant')
+        else:
+            warp = nib.Nifti1Image(warp_data, fixed.affine)
+
         moved_nii = nib.Nifti1Image(moved[0, ..., 0], fixed.affine)
         nib.save(moved_nii, os.path.join(f'{mov_im_path}_proc_reg_to_{fx_contrast}.nii.gz'))
         nib.save(warp, os.path.join(f'{mov_im_path}_proc_field_to_{fx_contrast}.nii.gz'))
         warp_in_original_space = resample_img(warp, target_affine=moving_nii.affine,
                                               target_shape=moving_nii.get_fdata().shape, interpolation='continuous')
         nib.save(warp_in_original_space, os.path.join(f'{mov_im_path}_warp_original_dim.nii.gz'))
+        
     else:
+        
         # ---- First registration ---- #
         warp_field_lst = []
         for fx_subvol, mov_subvol in zip(lst_subvol_fx, lst_subvol_mov):
@@ -321,16 +330,32 @@ def register(data, reg_model1, reg_model2, fx_im_path, mov_im_path, fx_contrast=
         is_warp_half_res = False if warp_field_lst[0].shape[0] == model_in_shape[0] else True
 
         if is_warp_half_res:
-            warp_field_lst_good_dim = []
-            for warp in warp_field_lst:
-                warp_field_lst_good_dim.append(zoom(warp, (2, 2, 2, 1)))
+            model_in_shape_first_reg = np.array(model_in_shape)
+            moving_shape = np.array(moving.shape)
+            for i in range(3):
+                model_in_shape_first_reg[i] = model_in_shape_first_reg[i] // 2
+                moving_shape[i] = moving_shape[i] // 2
+            new_coords = []
+            for coord in lst_coords_subvol:
+                x_min, x_max, y_min, y_max, z_min, z_max = coord
+                x_min, x_max, y_min, y_max, z_min, z_max = x_min // 2, x_max // 2, y_min // 2, y_max // 2, z_min // 2, z_max // 2
+                new_coords.append((x_min, x_max, y_min, y_max, z_min, z_max))
+            lst_coords_subvol = new_coords
         else:
-            warp_field_lst_good_dim = warp_field_lst
+            moving_shape = moving.shape
 
-        first_warp_field = get_def_field_from_subvol(model_in_shape, moving.shape,
-                                                     lst_coords_subvol, warp_field_lst_good_dim)
+        first_warp_field = get_def_field_from_subvol(model_in_shape_first_reg, moving_shape, lst_coords_subvol, warp_field_lst)
 
-        def_field_nii = nib.Nifti1Image(first_warp_field, affine=fixed.affine)
+        if is_warp_half_res:
+            warp_affine = np.copy(fixed.affine)
+            for i in range(3):
+                warp_affine[i, i] = warp_affine[i, i] * 2
+            warp = nib.Nifti1Image(first_warp_field, warp_affine)
+            def_field_nii = resample_nib(warp, new_size=[2, 2, 2, 1], new_size_type='factor', image_dest=None,
+                                         interpolation='spline', mode='constant')
+        else:
+            def_field_nii = nib.Nifti1Image(first_warp_field, affine=fixed.affine)
+
         nib.save(def_field_nii, os.path.join(f'{mov_im_path}_first_proc_field_to_{fx_contrast}.nii.gz'))
 
         moving = vxm.py.utils.load_volfile(os.path.join(f'{mov_im_path}_proc.nii.gz'),
@@ -357,19 +382,34 @@ def register(data, reg_model1, reg_model2, fx_im_path, mov_im_path, fx_contrast=
         is_warp_half_res = False if warp_field_lst[0].shape[0] == model_in_shape[0] else True
 
         if is_warp_half_res:
-            warp_field_lst_good_dim = []
-            for warp in warp_field_lst:
-                warp_field_lst_good_dim.append(zoom(warp, (2, 2, 2, 1)))
+            model_in_shape_second_reg = np.array(model_in_shape)
+            moving_shape = np.array(moving.shape)
+            for i in range(3):
+                model_in_shape_second_reg[i] = model_in_shape_second_reg[i] // 2
+                moving_shape[i] = moving_shape[i] // 2
+            new_coords = []
+            for coord in lst_coords_subvol:
+                x_min, x_max, y_min, y_max, z_min, z_max = coord
+                x_min, x_max, y_min, y_max, z_min, z_max = x_min // 2, x_max // 2, y_min // 2, y_max // 2, z_min // 2, z_max // 2
+                new_coords.append((x_min, x_max, y_min, y_max, z_min, z_max))
+            lst_coords_subvol = new_coords
         else:
-            warp_field_lst_good_dim = warp_field_lst
+            moving_shape = moving.shape
 
-        second_warp_field = get_def_field_from_subvol(model_in_shape, moving.shape,
-                                                      lst_coords_subvol, warp_field_lst_good_dim)
+        second_warp_field = get_def_field_from_subvol(model_in_shape_second_reg, moving_shape, lst_coords_subvol, warp_field_lst)
 
         warp = vxm.utils.compose([K.constant(first_warp_field), K.constant(second_warp_field)])
         warp_data = K.eval(warp)
 
-        def_field_nii = nib.Nifti1Image(warp_data, affine=fixed.affine)
+        if is_warp_half_res:
+            warp_affine = np.copy(fixed.affine)
+            for i in range(3):
+                warp_affine[i, i] = warp_affine[i, i] * 2
+            warp = nib.Nifti1Image(warp_data, warp_affine)
+            def_field_nii = resample_nib(warp, new_size=[2, 2, 2, 1], new_size_type='factor', image_dest=None,
+                                         interpolation='spline', mode='constant')
+        else:
+            def_field_nii = nib.Nifti1Image(warp_data, fixed.affine)
         nib.save(def_field_nii, os.path.join(f'{mov_im_path}_proc_field_to_{fx_contrast}.nii.gz'))
         warp_in_original_space = resample_img(def_field_nii, target_affine=moving_nii.affine,
                                               target_shape=moving_nii.get_fdata().shape, interpolation='continuous')

--- a/bids_two_steps_registration.py
+++ b/bids_two_steps_registration.py
@@ -271,8 +271,11 @@ def register(model_inference_specs, reg_model1, reg_model2, fx_im_path, mov_im_p
     Save the warped image and the deformation field.
     """
 
-    fixed_nii = nib.load(f'{fx_im_path}.nii.gz')
-    moving_nii = nib.load(f'{mov_im_path}.nii.gz')
+    fixed_nii = nib.load(fx_im_path)
+    moving_nii = nib.load(mov_im_path)
+
+    fx_im_path = fx_im_path.split(".")[0]
+    mov_im_path = mov_im_path.split(".")[0]
 
     fixed, moving, lst_subvol_fx, lst_subvol_mov, lst_coords_subvol = \
         preprocess(model_inference_specs, fixed_nii, moving_nii)

--- a/bids_two_steps_registration.py
+++ b/bids_two_steps_registration.py
@@ -11,6 +11,7 @@ The contrast of the fixed image can be specified as argument for the files namin
 import os
 import argparse
 
+import json
 import numpy as np
 import tensorflow as tf
 import tensorflow.keras.backend as K
@@ -465,6 +466,9 @@ if __name__ == "__main__":
     parser.add_argument('--model2-path', required=True, type=str,
                         help='path to the registration model (for deformable registration)')
 
+    parser.add_argument('--config-path', required=True, type=str,
+                        help='path to the config file with the inference models specificities')
+
     parser.add_argument('--fx-img-path', required=True, help='path to the fixed image')
     parser.add_argument('--mov-img-path', required=True, help='path to the moving image')
 
@@ -477,27 +481,13 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    # ***************************************************************************************
-    # TODO - Add a config file where the parameters are specified
-    # import json
-    # with open(args.config_path) as config_file:
-    #     model_inference_specs = json.load(config_file)
-
-    model_inference_specs = dict(
-        use_subvol=True,
-        subvol_size=[160, 160, 192],
-        min_perc_overlap=0.1,
-        int_steps=5,
-        int_res=2,
-        svf_res=2,
-        enc=[256, 256, 256, 256],
-        dec=[256, 256, 256, 256, 256, 256]
-    )
-    # ***************************************************************************************
+    with open(args.config_path) as config_file:
+        model_inference_specs = json.load(config_file)
 
     if eval(args.one_cpu_tf):
         # set that TF can use only one CPU
         session_conf = tf.compat.v1.ConfigProto(intra_op_parallelism_threads=1, inter_op_parallelism_threads=1)
         sess = tf.compat.v1.Session(config=session_conf)
 
-    run_main(model_inference_specs, args.model1_path, args.model2_path, args.fx_img_path, args.mov_img_path, args.fx_img_contrast)
+    run_main(model_inference_specs, args.model1_path, args.model2_path, 
+             args.fx_img_path, args.mov_img_path, args.fx_img_contrast)

--- a/bids_two_steps_registration.py
+++ b/bids_two_steps_registration.py
@@ -122,6 +122,54 @@ def preprocess(data, im_nii, mov_im_nii):
     return fx_preproc_nii, mov_preproc_nii, lst_subvol_fx, lst_subvol_mov, lst_coords_subvol
 
 
+def get_def_field_from_subvol(model_in_shape, im_shape, lst_coords_subvol, lst_warp_subvol):
+    """
+    Create a map of weights, apply it on the warping fields obtained with the different subvolumes,
+    construct the final warping field and return it
+    """
+    # Create a map of weights that will be applied on the different warping fields to reduce the boundaries effect
+    # via a weighted average of the overlapping volumes (between the volumes) giving more weights to the inside part
+    x, y, z = model_in_shape[0]//2, model_in_shape[1]//2, model_in_shape[2]//2
+    grid = np.mgrid[-x:x, -y:y, -z:z]
+    w_map = np.maximum(np.abs(grid[0]), np.abs(grid[1]))
+    w_map = np.maximum(w_map, np.abs(grid[2]))
+    # The center of the volume has a weight of 1 and then it decreases linearly towards the boundaries
+    w_map = 1 - w_map/(np.max(w_map) + 1)
+
+    # Get the map representing the weights of all the subvolumes and place the map to the correct location of each
+    # subvolume
+    sum_weights = np.zeros((im_shape[0], im_shape[1], im_shape[2]))
+    w_map_subvol_lst = []
+    warp_subvol_lst = []
+    for coords, warp in zip(lst_coords_subvol, lst_warp_subvol):
+        w_map_subvol = np.zeros((im_shape[0], im_shape[1], im_shape[2]))
+        warp_field_tmp = np.zeros((im_shape[0], im_shape[1], im_shape[2], 3))
+        x_min, x_max, y_min, y_max, z_min, z_max = coords
+        sum_weights[x_min:x_max, y_min:y_max, z_min:z_max] += w_map
+        w_map_subvol[x_min:x_max, y_min:y_max, z_min:z_max] = w_map
+        warp_field_tmp[x_min:x_max, y_min:y_max, z_min:z_max, :] = warp
+        w_map_subvol_lst.append(w_map_subvol)
+        warp_subvol_lst.append(warp_field_tmp)
+
+    # To avoid division by 0, replace the sum weights that are 0 by 1 before the division (may appear for the voxels
+    # at the border of the original volume if the size of this latter is even on certain axes)
+    sum_weights[sum_weights == 0] = 1
+
+    # Divide the weight map of each subvolume by the sum of all the weights of the different subvolumes to determine
+    # the relative weight of each subvolume in the prediction of the final displacement vector
+    w_map_subvol_final_lst = []
+    for w_map_subvol in w_map_subvol_lst:
+        w_map_subvol_final_lst.append(w_map_subvol/sum_weights)
+
+    # Reconstruct the warping field
+    warp_field = np.zeros((im_shape[0], im_shape[1], im_shape[2], 3))
+    for w_subvol, warp in zip(w_map_subvol_final_lst, warp_subvol_lst):
+        for i in range(3):
+            warp_field[..., i] += w_subvol * warp[..., i]
+
+    return warp_field
+
+
 def register(data, reg_model1, reg_model2, fx_im_path, mov_im_path, fx_contrast='T1w'):
     """
     Preprocess the two images and register the moving image to the fixed one using the provided model.
@@ -192,45 +240,8 @@ def register(data, reg_model1, reg_model2, fx_im_path, mov_im_path, fx_contrast=
         else:
             warp_field_lst_good_dim = warp_field_lst
 
-        # Create a map of weights that will be applied on the different warping fields to reduce the boundaries effect
-        # via a weighted average of the overlapping volumes (between the volumes) giving more weights to the inside part
-        x, y, z = model_in_shape[0]//2, model_in_shape[1]//2, model_in_shape[2]//2
-        grid = np.mgrid[-x:x, -y:y, -z:z]
-        w_map = np.maximum(np.abs(grid[0]), np.abs(grid[1]))
-        w_map = np.maximum(w_map, np.abs(grid[2]))
-        # The center of the volume has a weight of 1 and then it decreases linearly towards the boundaries
-        w_map = 1 - w_map/(np.max(w_map) + 1)
-
-        # Get the map representing the weights of all the subvolumes and place the map to the correct location of each
-        # subvolume
-        sum_weights = np.zeros((moving.shape[0], moving.shape[1], moving.shape[2]))
-        w_map_subvol_lst = []
-        warp_subvol_lst = []
-        for coords, warp in zip(lst_coords_subvol, warp_field_lst_good_dim):
-            w_map_subvol = np.zeros((moving.shape[0], moving.shape[1], moving.shape[2]))
-            warp_field_tmp = np.zeros((moving.shape[0], moving.shape[1], moving.shape[2], 3))
-            x_min, x_max, y_min, y_max, z_min, z_max = coords
-            sum_weights[x_min:x_max, y_min:y_max, z_min:z_max] += w_map
-            w_map_subvol[x_min:x_max, y_min:y_max, z_min:z_max] = w_map
-            warp_field_tmp[x_min:x_max, y_min:y_max, z_min:z_max, :] = warp
-            w_map_subvol_lst.append(w_map_subvol)
-            warp_subvol_lst.append(warp_field_tmp)
-
-        # To avoid division by 0, replace the sum weights that are 0 by 1 before the division (may appear for the voxels
-        # at the border of the original volume if the size of this latter is even on certain axes)
-        sum_weights[sum_weights == 0] = 1
-
-        # Divide the weight map of each subvolume by the sum of all the weights of the different subvolumes to determine
-        # the relative weight of each subvolume in the prediction of the final displacement vector
-        w_map_subvol_final_lst = []
-        for w_map_subvol in w_map_subvol_lst:
-            w_map_subvol_final_lst.append(w_map_subvol/sum_weights)
-
-        # Reconstruct the warping field
-        first_warp_field = np.zeros((moving.shape[0], moving.shape[1], moving.shape[2], 3))
-        for w_subvol, warp in zip(w_map_subvol_final_lst, warp_subvol_lst):
-            for i in range(3):
-                first_warp_field[..., i] += w_subvol * warp[..., i]
+        first_warp_field = get_def_field_from_subvol(model_in_shape, moving.shape,
+                                                     lst_coords_subvol, warp_field_lst_good_dim)
 
         def_field_nii = nib.Nifti1Image(first_warp_field, affine=fixed.affine)
         nib.save(def_field_nii, os.path.join(f'{mov_im_path}_first_proc_field_to_{fx_contrast}.nii.gz'))
@@ -265,36 +276,8 @@ def register(data, reg_model1, reg_model2, fx_im_path, mov_im_path, fx_contrast=
         else:
             warp_field_lst_good_dim = warp_field_lst
 
-        # Get the map representing the weights of all the subvolumes and place the map to the correct location of each
-        # subvolume
-        sum_weights = np.zeros((moving.shape[0], moving.shape[1], moving.shape[2]))
-        w_map_subvol_lst = []
-        warp_subvol_lst = []
-        for coords, warp in zip(lst_coords_subvol, warp_field_lst_good_dim):
-            w_map_subvol = np.zeros((moving.shape[0], moving.shape[1], moving.shape[2]))
-            warp_field_tmp = np.zeros((moving.shape[0], moving.shape[1], moving.shape[2], 3))
-            x_min, x_max, y_min, y_max, z_min, z_max = coords
-            sum_weights[x_min:x_max, y_min:y_max, z_min:z_max] += w_map
-            w_map_subvol[x_min:x_max, y_min:y_max, z_min:z_max] = w_map
-            warp_field_tmp[x_min:x_max, y_min:y_max, z_min:z_max, :] = warp
-            w_map_subvol_lst.append(w_map_subvol)
-            warp_subvol_lst.append(warp_field_tmp)
-
-        # To avoid division by 0, replace the sum weights that are 0 by 1 before the division (may appear for the voxels
-        # at the border of the original volume if the size of this latter is even on certain axes)
-        sum_weights[sum_weights == 0] = 1
-
-        # Divide the weight map of each subvolume by the sum of all the weights of the different subvolumes to determine
-        # the relative weight of each subvolume in the prediction of the final displacement vector
-        w_map_subvol_final_lst = []
-        for w_map_subvol in w_map_subvol_lst:
-            w_map_subvol_final_lst.append(w_map_subvol/sum_weights)
-
-        # Reconstruct the warping field
-        second_warp_field = np.zeros((moving.shape[0], moving.shape[1], moving.shape[2], 3))
-        for w_subvol, warp in zip(w_map_subvol_final_lst, warp_subvol_lst):
-            for i in range(3):
-                second_warp_field[..., i] += w_subvol * warp[..., i]
+        second_warp_field = get_def_field_from_subvol(model_in_shape, moving.shape,
+                                                      lst_coords_subvol, warp_field_lst_good_dim)
 
         warp = vxm.utils.compose([K.constant(first_warp_field), K.constant(second_warp_field)])
         warp_data = K.eval(warp)

--- a/bids_two_steps_registration.py
+++ b/bids_two_steps_registration.py
@@ -1,6 +1,6 @@
 """
 File to load two trained registration models and register two images together using the models one after the other.
-It includes a preprocessing step to transform the volumes to the dimensions required by the model.
+It includes a preprocessing step to scale the volumes and set it to an isotropic resolution of 1mm as required by the model.
 The images will be processed (and saved as im_name_proc) to be used in the registration model and then registered.
 The registered image is saved (as im_name_proc_reg_to_CONTRAST). The deformation field is also saved.
 This file can be used in a batch script to register the data of interest from all subjects in a dataset organized
@@ -18,19 +18,26 @@ import nibabel as nib
 import voxelmorph as vxm
 
 from nilearn.image import resample_img
+from scipy.ndimage import zoom
 
 
-def preprocess(im_nii, mov_im_nii, in_shape=(160, 160, 192)):
-    ''' Resize and normalize image. '''
+def preprocess(data, im_nii, mov_im_nii):
+    """
+    Scale volumes and set the voxel size to 1mm x 1mm x 1mm
+    If use subvolumes then create the subvolumes of the correct shape.
+    Return the preprocessed volumes (scaling, isotropic resolution of 1mm) as well as the
+    list of subvolumes for the fixed image, list of subvolumes for moving image and the coordinates of the subvolumes.
+    """
 
     # Scale the data between 0 and 1
-    img = im_nii.get_fdata()
-    scaled_img = (img - np.min(img)) / (np.max(img) - np.min(img))
-    scaled_nii = nib.Nifti1Image(scaled_img, im_nii.affine)
+    fx_img = im_nii.get_fdata()
+    scaled_fx_img = (fx_img - np.min(fx_img)) / (np.max(fx_img) - np.min(fx_img))
 
-    # sampling strategy: https://www.kaggle.com/mechaman/resizing-reshaping-and-resampling-nifti-files
-    # the brain images are mapped to the specified target shape at 1 mm isotropic resolution
-    target_shape = np.array(in_shape)
+    mov_img = mov_im_nii.get_fdata()
+    scaled_mov_img = (mov_img - np.min(mov_img)) / (np.max(mov_img) - np.min(mov_img))
+
+    # Change the resolution to isotropic 1 mm resolution
+    target_shape = np.array(scaled_fx_img.shape)
     new_resolution = [1, 1, 1]
     new_affine = np.zeros((4, 4))
     new_affine[:3, :3] = np.diag(new_resolution)
@@ -38,59 +45,281 @@ def preprocess(im_nii, mov_im_nii, in_shape=(160, 160, 192)):
     new_affine[:3, 3] = target_shape*new_resolution/2.*-1
     new_affine[3, 3] = 1.
 
-    # Resample the 3d image to be in the dimension expected by the registration model
-    resampled_nii = resample_img(scaled_nii, target_affine=new_affine,
-                                 target_shape=target_shape, interpolation='continuous')
+    # Resample the to obtain the resolution wanted
+    fx_resampled_nii = resample_img(nib.Nifti1Image(scaled_fx_img, im_nii.affine),
+                                    target_affine=new_affine, interpolation='continuous')
+    fx_img_res111 = fx_resampled_nii.get_fdata()
+    mov_resampled_nii = resample_img(nib.Nifti1Image(scaled_mov_img, mov_im_nii.affine),
+                                     target_affine=new_affine, interpolation='continuous')
+    mov_img_res111 = mov_resampled_nii.get_fdata()
 
-    # Scale the data between 0 and 1
-    mov_img = mov_im_nii.get_fdata()
-    scaled_mov_img = (mov_img - np.min(mov_img)) / (np.max(mov_img) - np.min(mov_img))
-    scaled_nii = nib.Nifti1Image(scaled_mov_img, mov_im_nii.affine)
+    fx_img_shape = fx_img_res111.shape
+    mov_img_shape = mov_img_res111.shape
 
-    # Resample the 3d image to be in the dimension expected by the registration model
-    mov_resampled_nii = resample_img(scaled_nii, target_affine=new_affine,
-                                     target_shape=target_shape, interpolation='continuous')
+    max_img_shape = max(fx_img_shape, mov_img_shape)
+    # Ensure that the volumes can be used in the registration model
+    new_img_shape = (int(np.ceil(max_img_shape[0] // 16)) * 16, int(np.ceil(max_img_shape[1] // 16)) * 16,
+                     int(np.ceil(max_img_shape[2] // 16)) * 16)
 
-    return resampled_nii, mov_resampled_nii
+    # Pad the volumes to the max shape
+    fx_img_pad_nii = resample_img(fx_resampled_nii, target_affine=new_affine,
+                                  target_shape=new_img_shape, interpolation='continuous')
+    fx_img_pad = fx_img_pad_nii.get_fdata()
+    mov_img_pad_nii = resample_img(mov_resampled_nii, target_affine=new_affine,
+                                   target_shape=new_img_shape, interpolation='continuous')
+    mov_img_pad = mov_img_pad_nii.get_fdata()
+
+    if data['use_subvol']:
+
+        in_shape = (int(np.ceil(data['subvol_size'][0] // 16)) * 16, int(np.ceil(data['subvol_size'][1] // 16)) * 16,
+                    int(np.ceil(data['subvol_size'][2] // 16)) * 16)
+
+        # Determine how many subvolumes have to be created
+        shape_in_vol = fx_img_pad.shape
+        min_perc = 0.1
+
+        nb_sub_x_axis = int(shape_in_vol[0] / (in_shape[0] - min_perc * in_shape[0])) + 1
+        nb_sub_y_axis = int(shape_in_vol[1] / (in_shape[1] - min_perc * in_shape[1])) + 1
+        nb_sub_z_axis = int(shape_in_vol[2] / (in_shape[2] - min_perc * in_shape[2])) + 1
+
+        # Determine the number of overlapping voxels for each axis
+        x_vox_overlap, y_vox_overlap, z_vox_overlap = 0, 0, 0
+        if nb_sub_x_axis > 1:
+            x_vox_overlap = (in_shape[0] - (shape_in_vol[0]/nb_sub_x_axis)) * (nb_sub_x_axis/(nb_sub_x_axis - 1))
+        if nb_sub_y_axis > 1:
+            y_vox_overlap = (in_shape[1] - (shape_in_vol[1]/nb_sub_y_axis)) * (nb_sub_y_axis/(nb_sub_y_axis - 1))
+        if nb_sub_z_axis > 1:
+            z_vox_overlap = (in_shape[2] - (shape_in_vol[2]/nb_sub_z_axis)) * (nb_sub_z_axis/(nb_sub_z_axis - 1))
+
+        # Get the subvolumes and the coordinates of the x_min, x_max, y_min, y_max, z_min, z_max
+        lst_subvol_fx = []
+        lst_subvol_mov = []
+        lst_coords_subvol = []
+
+        x_max, y_max, z_max = 0, 0, 0
+        for i in range(nb_sub_x_axis):
+            x_min = 0 if i == 0 else int(x_max - x_vox_overlap)
+            x_max = int(x_min + in_shape[0])
+            for j in range(nb_sub_y_axis):
+                y_min = 0 if j == 0 else int(y_max - y_vox_overlap)
+                y_max = int(y_min + in_shape[1])
+                for k in range(nb_sub_z_axis):
+                    z_min = 0 if k == 0 else int(z_max - z_vox_overlap)
+                    z_max = int(z_min + in_shape[2])
+                    subvol_fx = fx_img_pad[x_min:x_max, y_min:y_max, z_min:z_max]
+                    subvol_mov = mov_img_pad[x_min:x_max, y_min:y_max, z_min:z_max]
+
+                    lst_subvol_fx.append(subvol_fx)
+                    lst_subvol_mov.append(subvol_mov)
+                    lst_coords_subvol.append((x_min, x_max, y_min, y_max, z_min, z_max))
+    else:
+        lst_subvol_fx, lst_subvol_mov, lst_coords_subvol = [], [], []
+
+    # Create nifti files with the preprocessed volumes
+    fx_preproc_nii = nib.Nifti1Image(fx_img_pad, new_affine)
+    mov_preproc_nii = nib.Nifti1Image(mov_img_pad, new_affine)
+
+    return fx_preproc_nii, mov_preproc_nii, lst_subvol_fx, lst_subvol_mov, lst_coords_subvol
 
 
-def register(reg_model1, reg_model2, fx_im_path, mov_im_path, fx_contrast='T1w', already_preproc=0):
+def register(data, reg_model1, reg_model2, fx_im_path, mov_im_path, fx_contrast='T1w'):
     """
     Preprocess the two images and register the moving image to the fixed one using the provided model.
     Save the warped image and the deformation field.
     """
 
-    if already_preproc:
-        fixed = nib.load(f'{fx_im_path}.nii.gz')
-        moving = nib.load(f'{mov_im_path}.nii.gz')
+    fixed_nii = nib.load(f'{fx_im_path}.nii.gz')
+    moving_nii = nib.load(f'{mov_im_path}.nii.gz')
+
+    fixed, moving, lst_subvol_fx, lst_subvol_mov, lst_coords_subvol = \
+        preprocess(data, fixed_nii, moving_nii)
+
+    nib.save(fixed, os.path.join(f'{fx_im_path}_proc.nii.gz'))
+    nib.save(moving, os.path.join(f'{mov_im_path}_proc.nii.gz'))
+
+    if data['use_subvol']:
+        model_in_shape = (int(np.ceil(data['subvol_size'][0] // 16)) * 16, int(np.ceil(data['subvol_size'][1] // 16)) * 16,
+                          int(np.ceil(data['subvol_size'][2] // 16)) * 16)
     else:
-        model_in_shape = reg_model1.inputs[0].shape[1:-1]
+        model_in_shape = fixed.get_fdata().shape
 
-        fixed_nii = nib.load(f'{fx_im_path}.nii.gz')
-        moving_nii = nib.load(f'{mov_im_path}.nii.gz')
+    reg_args = dict(
+        inshape=model_in_shape,
+        int_steps=data['int_steps'],
+        int_resolution=data['int_res'],
+        svf_resolution=data['svf_res'],
+        nb_unet_features=(data['enc'], data['dec'])
+    )
 
-        fixed, moving = preprocess(fixed_nii, moving_nii, model_in_shape)
+    model1 = vxm.networks.VxmDense(**reg_args)
+    model1.set_weights(reg_model1.get_weights())
 
-        nib.save(fixed, os.path.join(f'{fx_im_path}_proc.nii.gz'))
-        nib.save(moving, os.path.join(f'{mov_im_path}_proc.nii.gz'))
+    model2 = vxm.networks.VxmDense(**reg_args)
+    model2.set_weights(reg_model2.get_weights())
 
-    moved_first_reg, warp_first_reg = reg_model1.predict([np.expand_dims(moving.get_fdata().squeeze(), axis=(0, -1)),
+    if not data['use_subvol']:
+        moved_first_reg, warp_first_reg = model1.predict([np.expand_dims(moving.get_fdata().squeeze(), axis=(0, -1)),
                                                           np.expand_dims(fixed.get_fdata().squeeze(), axis=(0, -1))])
-
-    moved, warp_second_reg = reg_model2.predict([moved_first_reg,
+        moved, warp_second_reg = model2.predict([moved_first_reg,
                                                  np.expand_dims(fixed.get_fdata().squeeze(), axis=(0, -1))])
 
-    warp = vxm.utils.compose([K.constant(warp_first_reg[0, ...]), K.constant(warp_second_reg[0, ...])])
-    warp_arr = K.eval(warp)
+        warp = vxm.utils.compose([K.constant(warp_first_reg[0, ...]), K.constant(warp_second_reg[0, ...])])
+        warp_data = K.eval(warp)
+        is_warp_half_res = False if warp_data.shape[0] == model_in_shape[0] else True
+        if is_warp_half_res:
+            warp_data = zoom(warp_data, (2, 2, 2, 1))
+        warp = nib.Nifti1Image(warp_data, fixed.affine)
+        moved_nii = nib.Nifti1Image(moved[0, ..., 0], fixed.affine)
+        nib.save(moved_nii, os.path.join(f'{mov_im_path}_proc_reg_to_{fx_contrast}.nii.gz'))
+        nib.save(warp, os.path.join(f'{mov_im_path}_proc_field_to_{fx_contrast}.nii.gz'))
+        warp_in_original_space = resample_img(warp, target_affine=moving_nii.affine,
+                                              target_shape=moving_nii.get_fdata().shape, interpolation='continuous')
+        nib.save(warp_in_original_space, os.path.join(f'{mov_im_path}_warp_original_dim.nii.gz'))
+    else:
+        # ---- First registration ---- #
+        warp_field_lst = []
+        for fx_subvol, mov_subvol in zip(lst_subvol_fx, lst_subvol_mov):
+            _, warp_first_reg = model1.predict([np.expand_dims(mov_subvol.squeeze(), axis=(0, -1)),
+                                                np.expand_dims(fx_subvol.squeeze(), axis=(0, -1))])
+            warp_field_lst.append(warp_first_reg[0, ...])
 
-    moved = nib.Nifti1Image(moved[0, ..., 0], fixed.affine)
-    warp = nib.Nifti1Image(warp_arr, fixed.affine)
+        is_warp_half_res = False if warp_field_lst[0].shape[0] == model_in_shape[0] else True
 
-    nib.save(moved, os.path.join(f'{mov_im_path}_proc_reg_to_{fx_contrast}.nii.gz'))
-    nib.save(warp, os.path.join(f'{mov_im_path}_proc_field_to_{fx_contrast}.nii.gz'))
+        if is_warp_half_res:
+            warp_field_lst_good_dim = []
+            for warp in warp_field_lst:
+                warp_field_lst_good_dim.append(zoom(warp, (2, 2, 2, 1)))
+        else:
+            warp_field_lst_good_dim = warp_field_lst
+
+        # Create a map of weights that will be applied on the different warping fields to reduce the boundaries effect
+        # via a weighted average of the overlapping volumes (between the volumes) giving more weights to the inside part
+        x, y, z = model_in_shape[0]//2, model_in_shape[1]//2, model_in_shape[2]//2
+        grid = np.mgrid[-x:x, -y:y, -z:z]
+        w_map = np.maximum(np.abs(grid[0]), np.abs(grid[1]))
+        w_map = np.maximum(w_map, np.abs(grid[2]))
+        # The center of the volume has a weight of 1 and then it decreases linearly towards the boundaries
+        w_map = 1 - w_map/(np.max(w_map) + 1)
+
+        # Get the map representing the weights of all the subvolumes and place the map to the correct location of each
+        # subvolume
+        sum_weights = np.zeros((moving.shape[0], moving.shape[1], moving.shape[2]))
+        w_map_subvol_lst = []
+        warp_subvol_lst = []
+        for coords, warp in zip(lst_coords_subvol, warp_field_lst_good_dim):
+            w_map_subvol = np.zeros((moving.shape[0], moving.shape[1], moving.shape[2]))
+            warp_field_tmp = np.zeros((moving.shape[0], moving.shape[1], moving.shape[2], 3))
+            x_min, x_max, y_min, y_max, z_min, z_max = coords
+            sum_weights[x_min:x_max, y_min:y_max, z_min:z_max] += w_map
+            w_map_subvol[x_min:x_max, y_min:y_max, z_min:z_max] = w_map
+            warp_field_tmp[x_min:x_max, y_min:y_max, z_min:z_max, :] = warp
+            w_map_subvol_lst.append(w_map_subvol)
+            warp_subvol_lst.append(warp_field_tmp)
+
+        # To avoid division by 0, replace the sum weights that are 0 by 1 before the division (may appear for the voxels
+        # at the border of the original volume if the size of this latter is even on certain axes)
+        sum_weights[sum_weights == 0] = 1
+
+        # Divide the weight map of each subvolume by the sum of all the weights of the different subvolumes to determine
+        # the relative weight of each subvolume in the prediction of the final displacement vector
+        w_map_subvol_final_lst = []
+        for w_map_subvol in w_map_subvol_lst:
+            w_map_subvol_final_lst.append(w_map_subvol/sum_weights)
+
+        # Reconstruct the warping field
+        first_warp_field = np.zeros((moving.shape[0], moving.shape[1], moving.shape[2], 3))
+        for w_subvol, warp in zip(w_map_subvol_final_lst, warp_subvol_lst):
+            for i in range(3):
+                first_warp_field[..., i] += w_subvol * warp[..., i]
+
+        def_field_nii = nib.Nifti1Image(first_warp_field, affine=fixed.affine)
+        nib.save(def_field_nii, os.path.join(f'{mov_im_path}_first_proc_field_to_{fx_contrast}.nii.gz'))
+
+        moving = vxm.py.utils.load_volfile(os.path.join(f'{mov_im_path}_proc.nii.gz'),
+                                           add_batch_axis=True, add_feat_axis=True)
+        warp_to_apply = vxm.py.utils.load_volfile(os.path.join(f'{mov_im_path}_first_proc_field_to_{fx_contrast}.nii.gz'),
+                                                  add_batch_axis=True, ret_affine=True)
+
+        first_moved = vxm.networks.Transform(moving.shape[1:-1], nb_feats=moving.shape[-1]).predict([moving, warp_to_apply[0]])
+        first_moved_data = first_moved.squeeze()
+        first_moved_nii = nib.Nifti1Image(first_moved_data, fixed.affine)
+
+        # save moved image
+        vxm.py.utils.save_volfile(first_moved_data, os.path.join(f'{mov_im_path}_proc_first_reg_to_{fx_contrast}.nii.gz'), fixed.affine)
+
+        # ---- Second registration ---- #
+        fixed, moving, lst_subvol_fx, lst_subvol_mov, lst_coords_subvol = preprocess(data, fixed_nii, first_moved_nii)
+
+        warp_field_lst = []
+        for fx_subvol, mov_subvol in zip(lst_subvol_fx, lst_subvol_mov):
+            _, warp_second_reg = model2.predict([np.expand_dims(mov_subvol.squeeze(), axis=(0, -1)),
+                                                 np.expand_dims(fx_subvol.squeeze(), axis=(0, -1))])
+            warp_field_lst.append(warp_second_reg[0, ...])
+
+        is_warp_half_res = False if warp_field_lst[0].shape[0] == model_in_shape[0] else True
+
+        if is_warp_half_res:
+            warp_field_lst_good_dim = []
+            for warp in warp_field_lst:
+                warp_field_lst_good_dim.append(zoom(warp, (2, 2, 2, 1)))
+        else:
+            warp_field_lst_good_dim = warp_field_lst
+
+        # Get the map representing the weights of all the subvolumes and place the map to the correct location of each
+        # subvolume
+        sum_weights = np.zeros((moving.shape[0], moving.shape[1], moving.shape[2]))
+        w_map_subvol_lst = []
+        warp_subvol_lst = []
+        for coords, warp in zip(lst_coords_subvol, warp_field_lst_good_dim):
+            w_map_subvol = np.zeros((moving.shape[0], moving.shape[1], moving.shape[2]))
+            warp_field_tmp = np.zeros((moving.shape[0], moving.shape[1], moving.shape[2], 3))
+            x_min, x_max, y_min, y_max, z_min, z_max = coords
+            sum_weights[x_min:x_max, y_min:y_max, z_min:z_max] += w_map
+            w_map_subvol[x_min:x_max, y_min:y_max, z_min:z_max] = w_map
+            warp_field_tmp[x_min:x_max, y_min:y_max, z_min:z_max, :] = warp
+            w_map_subvol_lst.append(w_map_subvol)
+            warp_subvol_lst.append(warp_field_tmp)
+
+        # To avoid division by 0, replace the sum weights that are 0 by 1 before the division (may appear for the voxels
+        # at the border of the original volume if the size of this latter is even on certain axes)
+        sum_weights[sum_weights == 0] = 1
+
+        # Divide the weight map of each subvolume by the sum of all the weights of the different subvolumes to determine
+        # the relative weight of each subvolume in the prediction of the final displacement vector
+        w_map_subvol_final_lst = []
+        for w_map_subvol in w_map_subvol_lst:
+            w_map_subvol_final_lst.append(w_map_subvol/sum_weights)
+
+        # Reconstruct the warping field
+        second_warp_field = np.zeros((moving.shape[0], moving.shape[1], moving.shape[2], 3))
+        for w_subvol, warp in zip(w_map_subvol_final_lst, warp_subvol_lst):
+            for i in range(3):
+                second_warp_field[..., i] += w_subvol * warp[..., i]
+
+        warp = vxm.utils.compose([K.constant(first_warp_field), K.constant(second_warp_field)])
+        warp_data = K.eval(warp)
+
+        def_field_nii = nib.Nifti1Image(warp_data, affine=fixed.affine)
+        nib.save(def_field_nii, os.path.join(f'{mov_im_path}_proc_field_to_{fx_contrast}.nii.gz'))
+
+        moving = vxm.py.utils.load_volfile(os.path.join(f'{mov_im_path}_proc.nii.gz'),
+                                           add_batch_axis=True, add_feat_axis=True)
+        warp_to_apply = vxm.py.utils.load_volfile(os.path.join(f'{mov_im_path}_proc_field_to_{fx_contrast}.nii.gz'),
+                                                  add_batch_axis=True, ret_affine=True)
+
+        moved = vxm.networks.Transform(moving.shape[1:-1], nb_feats=moving.shape[-1]).predict([moving, warp_to_apply[0]])
+
+        # save moved image
+        vxm.py.utils.save_volfile(moved.squeeze(), os.path.join(f'{mov_im_path}_proc_reg_to_{fx_contrast}.nii.gz'), fixed.affine)
+
+    moved_data = moved.squeeze()
+    moved_nii = nib.Nifti1Image(moved_data, fixed.affine)
+    moved_in_original_space = resample_img(moved_nii, target_affine=moving_nii.affine,
+                                           target_shape=moving_nii.get_fdata().shape, interpolation='continuous')
+    nib.save(moved_in_original_space, os.path.join(f'{mov_im_path}_reg_original_dim.nii.gz'))
 
 
-def run_main(reg_model1_path, reg_model2_path, fx_im_path, mov_im_path, fx_im_contrast='T1w', already_preproc=0):
+def run_main(data, reg_model1_path, reg_model2_path, fx_im_path, mov_im_path, fx_im_contrast='T1w'):
     """
     Load the registration model
     Preprocess the fixed and moving images
@@ -100,7 +329,7 @@ def run_main(reg_model1_path, reg_model2_path, fx_im_path, mov_im_path, fx_im_co
     model1 = vxm.networks.VxmDense.load(reg_model1_path, input_model=None)
     model2 = vxm.networks.VxmDense.load(reg_model2_path, input_model=None)
 
-    register(model1, model2, fx_im_path, mov_im_path, fx_contrast=fx_im_contrast, already_preproc=already_preproc)
+    register(data, model1, model2, fx_im_path, mov_im_path, fx_contrast=fx_im_contrast)
 
 
 if __name__ == "__main__":
@@ -124,15 +353,28 @@ if __name__ == "__main__":
                         help='boolean to determine if the processes link to TF have access to one CPU (True) or all '
                              'the CPUs (False) {\'0\',\'1\', \'False\',\'True\'}')
 
-    parser.add_argument('--already-preproc', type=int, required=False, default=0, choices=[0, 1],
-                        help='Specify if the preprocessing step has already been done (1) or not (0)')
-
     args = parser.parse_args()
+
+    # ***************************************************************************************
+    # TODO - Add a config file where the parameters are specified
+    # import json
+    # with open(args.config_path) as config_file:
+    #     data = json.load(config_file)
+
+    data = dict(
+        use_subvol=True,
+        subvol_size=[160, 160, 192],
+        int_steps=5,
+        int_res=2,
+        svf_res=2,
+        enc=[256, 256, 256, 256],
+        dec=[256, 256, 256, 256, 256, 256]
+    )
+    # ***************************************************************************************
 
     if eval(args.one_cpu_tf):
         # set that TF can use only one CPU
         session_conf = tf.compat.v1.ConfigProto(intra_op_parallelism_threads=1, inter_op_parallelism_threads=1)
         sess = tf.compat.v1.Session(config=session_conf)
 
-    run_main(args.model1_path, args.model2_path, args.fx_img_path,
-             args.mov_img_path, args.fx_img_contrast, args.already_preproc)
+    run_main(data, args.model1_path, args.model2_path, args.fx_img_path, args.mov_img_path, args.fx_img_contrast)

--- a/config/README.md
+++ b/config/README.md
@@ -1,4 +1,4 @@
-## Parameters description
+## Training parameters description
 Description of the different parameters that can be modified/specified in the config file to use `train_synthmorph.py` in order to generate synthetic label maps, to generate synthetic grayscale images and to train a model for multimodal registration.
 
 ### Data organization parameters
@@ -54,3 +54,19 @@ Description of the different parameters that can be modified/specified in the co
 - `svf_res`: resolution (relative voxel size) of the predicted SVF (default: 2)
 - `enc`: U-net encoder filters (default: 64 64 64 64)
 - `dec`: U-net decoder filters (default: 64 64 64 64 64 64)
+
+---
+## Inference parameters description
+Description of the different parameters that can be modified/specified in the config_inference file to use `3d_reg.py` and the different shell scripts like `bids_register_evaluate.sh`. Some of these parameters need to be the same as the ones used to train the registration model, whereas the first parameters others are specific to the strategy wanted for the registratrion during inference time. You can choose between doing the inference directly on the whole volume (better accuracy but greater computational resources needed) or on subvolumes of the size specified.
+
+### Parameters independent from the trained registration model
+- `use_subvol`: boolean to decide whether to use the whole volume as input of the registration model (False) (better results, more computational resources needed) or to create subvolumes to use as input of the registration model (True) before constructing the warping field that will be applied to the whole volume (default: false)
+- `subvol_size`: the size of the subvolumes used (if `use_subvol` is true). Need to be a list of 3 elements representing the size used for each dimension (default: [80, 80, 96])
+- `min_perc_overlap`: the minimum percentage of overlap of the subvolumes (if `use_subvol` is true). Can be in percent (ex: 10) or in fraction (ex: 0.1) (default: 0.1)
+
+### Parameters that need to be similar to the ones used to train the registration model
+- `int_steps`: number of integration steps (default: 5)
+- `int_res`: resolution (relative voxel size) of the flow field during vector integration (default: 2)
+- `svf_res`: resolution (relative voxel size) of the predicted SVF (default: 2)
+- `enc`: U-net encoder filters (default: [256, 256, 256, 256])
+- `dec`: U-net decoder filters (default: [256, 256, 256, 256, 256, 256])

--- a/config/config_inference.json
+++ b/config/config_inference.json
@@ -1,0 +1,10 @@
+{
+  "use_subvol": false,
+  "subvol_size": [80, 80, 96],
+  "min_perc_overlap": 0.1,
+  "int_steps": 5,
+  "int_res": 2,
+  "svf_res": 2,
+  "enc": [256, 256, 256, 256],
+  "dec": [256, 256, 256, 256, 256, 256]
+}

--- a/pipeline_bids_register_evaluate.sh
+++ b/pipeline_bids_register_evaluate.sh
@@ -69,8 +69,8 @@ rsync -avzh $PATH_DATA/$SUBJECT/ ${SUBJECT}
 echo $PWD
 cd ${SUBJECT}/anat/
 
-file_t1_before_proc="${SES}_T1w"
-file_t2_before_proc="${SES}_T2w"
+file_t1_before_proc="${SES}_T1w.nii.gz"
+file_t2_before_proc="${SES}_T2w.nii.gz"
 
 CONDA_BASE=$(conda info --base)
 source $CONDA_BASE/etc/profile.d/conda.sh

--- a/pipeline_bids_register_evaluate.sh
+++ b/pipeline_bids_register_evaluate.sh
@@ -54,9 +54,11 @@ DEBUGGING=1
 # Choose whether to keep original naming and location of input volumes for the registered volumes. It's recommended to set the value to 1 if the dataset
 # will later be used for other tasks, such as segmentation. If the value is 1, the res folder will be removed and the
 # registered volumes will be directly present in the anat folder and with the same names as the original volumes
-KEEP_ORI_NAMING_LOC=1
+KEEP_ORI_NAMING_LOC=0
 # Choose the registration model to use (should be in the model folder)
 REGISTRATION_MODEL="registration_model.h5"
+# Choose the config file to use (should be in the config folder)
+INFERENCE_CONFIG='config_inference.json'
 
 # Go to folder where data will be copied and processed
 cd ${PATH_DATA_PROCESSED}
@@ -74,7 +76,7 @@ CONDA_BASE=$(conda info --base)
 source $CONDA_BASE/etc/profile.d/conda.sh
 conda activate smenv
 # Perform processing and registration
-python $PATH_SCRIPT/bids_registration.py --model-path $PATH_SCRIPT/model/$REGISTRATION_MODEL --fx-img-path $file_t1_before_proc --mov-img-path $file_t2_before_proc --fx-img-contrast T1w --one-cpu-tf True
+python $PATH_SCRIPT/bids_registration.py --model-path $PATH_SCRIPT/model/$REGISTRATION_MODEL --config-path $PATH_SCRIPT/config/$INFERENCE_CONFIG --fx-img-path $file_t1_before_proc --mov-img-path $file_t2_before_proc --fx-img-contrast T1w --one-cpu-tf False
 conda deactivate
 
 file_t1="${SES}_T1w_proc"

--- a/pipeline_bids_register_evaluate_opt_affine.sh
+++ b/pipeline_bids_register_evaluate_opt_affine.sh
@@ -57,9 +57,11 @@ DEBUGGING=1
 # Choose whether to keep original naming and location of input volumes for the registered volumes. It's recommended to set the value to 1 if the dataset
 # will later be used for other tasks, such as segmentation. If the value is 1, the res folder will be removed and the
 # registered volumes will be directly present in the anat folder and with the same names as the original volumes
-KEEP_ORI_NAMING_LOC=1
+KEEP_ORI_NAMING_LOC=0
 # Choose the registration model to use (should be in the model folder)
 REGISTRATION_MODEL="registration_model.h5"
+# Choose the config file to use (should be in the config folder)
+INFERENCE_CONFIG='config_inference.json'
 # Set the following value to 0 to not perform affine registration in any case
 MIN_SC_DICE_EXPECTED_PERC=80
 
@@ -79,7 +81,7 @@ CONDA_BASE=$(conda info --base)
 source $CONDA_BASE/etc/profile.d/conda.sh
 conda activate smenv
 # Perform processing and registration
-python $PATH_SCRIPT/bids_registration.py --model-path $PATH_SCRIPT/model/$REGISTRATION_MODEL --fx-img-path $file_t1_before_proc --mov-img-path $file_t2_before_proc --fx-img-contrast T1w --one-cpu-tf True
+python $PATH_SCRIPT/bids_registration.py --model-path $PATH_SCRIPT/model/$REGISTRATION_MODEL --config-path $PATH_SCRIPT/config/$INFERENCE_CONFIG --fx-img-path $file_t1_before_proc --mov-img-path $file_t2_before_proc --fx-img-contrast T1w --one-cpu-tf False
 conda deactivate
 
 file_t1="${SES}_T1w_proc"
@@ -126,7 +128,7 @@ then
 
   conda activate smenv
   # Perform processing and model's registration
-  python $PATH_SCRIPT/bids_registration.py --model-path $PATH_SCRIPT/model/$REGISTRATION_MODEL --fx-img-path $file_t1_before_proc --mov-img-path $file_t2_before_proc --fx-img-contrast T1w --one-cpu-tf False
+  python $PATH_SCRIPT/bids_registration.py --model-path $PATH_SCRIPT/model/$REGISTRATION_MODEL --config-path $PATH_SCRIPT/config/$INFERENCE_CONFIG --fx-img-path $file_t1_before_proc --mov-img-path $file_t2_before_proc --fx-img-contrast T1w --one-cpu-tf False
   conda deactivate
 
   file_t2="${SES}_T2w_aff_reg_proc"

--- a/pipeline_bids_register_evaluate_opt_affine.sh
+++ b/pipeline_bids_register_evaluate_opt_affine.sh
@@ -74,8 +74,8 @@ rsync -avzh $PATH_DATA/$SUBJECT/ ${SUBJECT}
 echo $PWD
 cd ${SUBJECT}/anat/
 
-file_t1_before_proc="${SES}_T1w"
-file_t2_before_proc="${SES}_T2w"
+file_t1_before_proc="${SES}_T1w.nii.gz"
+file_t2_before_proc="${SES}_T2w.nii.gz"
 
 CONDA_BASE=$(conda info --base)
 source $CONDA_BASE/etc/profile.d/conda.sh

--- a/pipeline_bids_register_evaluate_two_steps.sh
+++ b/pipeline_bids_register_evaluate_two_steps.sh
@@ -56,7 +56,7 @@ DEBUGGING=1
 # Choose whether to keep original naming and location of input volumes for the registered volumes. It's recommended to set the value to 1 if the dataset
 # will later be used for other tasks, such as segmentation. If the value is 1, the res folder will be removed and the
 # registered volumes will be directly present in the anat folder and with the same names as the original volumes
-KEEP_ORI_NAMING_LOC=1
+KEEP_ORI_NAMING_LOC=0
 
 # Choose the registration model to use for the first step (should be in the model folder)
 # This model should ideally be more specific to affine registration (the model has learned to deal with regularized deformation fields)
@@ -84,7 +84,7 @@ source $CONDA_BASE/etc/profile.d/conda.sh
 conda activate smenv
 # ---- First & Second registration steps ---- #
 # Perform processing and registration
-python $PATH_SCRIPT/bids_two_steps_registration.py --model1-path $PATH_SCRIPT/model/$AFFINE_REGISTRATION_MODEL --model2-path $PATH_SCRIPT/model/$DEFORMABLE_REGISTRATION_MODEL --fx-img-path $file_t1_before_proc --mov-img-path $file_t2_before_proc --fx-img-contrast T1w --one-cpu-tf True
+python $PATH_SCRIPT/bids_two_steps_registration.py --model1-path $PATH_SCRIPT/model/$AFFINE_REGISTRATION_MODEL --model2-path $PATH_SCRIPT/model/$DEFORMABLE_REGISTRATION_MODEL --config-path $PATH_SCRIPT/config/$INFERENCE_CONFIG --fx-img-path $file_t1_before_proc --mov-img-path $file_t2_before_proc --fx-img-contrast T1w --one-cpu-tf False
 conda deactivate
 
 file_t1="${SES}_T1w_proc"

--- a/pipeline_bids_register_evaluate_two_steps.sh
+++ b/pipeline_bids_register_evaluate_two_steps.sh
@@ -75,8 +75,8 @@ rsync -avzh $PATH_DATA/$SUBJECT/ ${SUBJECT}
 echo $PWD
 cd ${SUBJECT}/anat/
 
-file_t1_before_proc="${SES}_T1w"
-file_t2_before_proc="${SES}_T2w"
+file_t1_before_proc="${SES}_T1w.nii.gz"
+file_t2_before_proc="${SES}_T2w.nii.gz"
 
 CONDA_BASE=$(conda info --base)
 source $CONDA_BASE/etc/profile.d/conda.sh


### PR DESCRIPTION
Implementation allowing to use the registration model on input of any size during inference without having to crop them and losing information before using the registration model. 

The user can choose whether to do the registration directly on the whole volume (more accurate but need more computational resources) or on subvolumes (with a size specified by the user). This can be chosen in the .py file but will be done through a config file later. 

When using subvolumes, the final deformation field to apply to the original volume is obtained by using all the deformation fields outputted by the model for the different subvolumes and doing a weighted average of the displacement vectors on the overlapping areas (giving more weights to voxels closer to the center of the subvolume than to the ones closer to the boundaries). The weighted average of the displacement vectors allow to obtain a smooth deformation field without sharp transitions delimiting the different subvolumes used. 

The registration using volume of any size during inference has been implemented for the normal registration strategy and for the two steps strategy.