### PR TITLE
Let the user choose the warping interpolation

### DIFF
--- a/bids_two_steps_registration.py
+++ b/bids_two_steps_registration.py
@@ -324,12 +324,21 @@ def register(model_inference_specs, reg_model1, reg_model2, fx_im_path, mov_im_p
         else:
             warp = nib.Nifti1Image(warp_data, fixed.affine)
 
-        moved_nii = nib.Nifti1Image(moved[0, ..., 0], fixed.affine)
-        nib.save(moved_nii, os.path.join(f'{mov_im_path}_proc_reg_to_{fx_contrast}.nii.gz'))
         nib.save(warp, os.path.join(f'{mov_im_path}_proc_field_to_{fx_contrast}.nii.gz'))
         warp_in_original_space = resample_img(warp, target_affine=moving_nii.affine,
                                               target_shape=moving_nii.get_fdata().shape, interpolation='continuous')
         nib.save(warp_in_original_space, os.path.join(f'{mov_im_path}_warp_original_dim.nii.gz'))
+
+        moving = vxm.py.utils.load_volfile(os.path.join(f'{mov_im_path}_proc.nii.gz'),
+                                           add_batch_axis=True, add_feat_axis=True)
+        deform = vxm.py.utils.load_volfile(os.path.join(f'{mov_im_path}_proc_field_to_{fx_contrast}.nii.gz'),
+                                           add_batch_axis=True, ret_affine=True)
+
+        moved = vxm.networks.Transform(moving.shape[1:-1],
+                                       interp_method='linear',
+                                       nb_feats=moving.shape[-1]).predict([moving, deform[0]])
+        vxm.py.utils.save_volfile(moved.squeeze(), os.path.join(f'{mov_im_path}_proc_reg_to_{fx_contrast}.nii.gz'),
+                                  fixed.affine)
         
     else:
         


### PR DESCRIPTION
Once the registration model has outputted a warping field, this latter should be applied to the moving image in order to obtain the moved image that is registered with the fixed one. 

Applying the warping field to the moving image, leads to the displacement of each voxel which is done through a transformation involving an interpolation step. Originally, this interpolation was always linear. With this PR, some arguments and parameters will be created to let the user choose whether he wants a linear interpolation or a nearest neighbor interpolation. 

The following example illustrates the difference in the two approaches:

![ezgif com-gif-maker - 2022-02-01T092309 147](https://user-images.githubusercontent.com/32447627/151988146-10879006-9173-43c8-bc56-a3829d447c22.gif)

