### PR TITLE
Generalize the pipeline

### DIFF
--- a/pipeline_bids_register_evaluate.sh
+++ b/pipeline_bids_register_evaluate.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 #
-# Register T2w volumes to T1w volumes and evaluate the registration by computing the volume overlap of the spinal cord
+# Register moving volumes to fixed volumes and evaluate the registration by computing the volume overlap of the spinal cord
 # segmentations of the volumes involved in the process and the mutual information between these volumes as well
+# Specify at the start of the script the contrasts to register together, the registration model and the config file to use
+# Specify if multi-sessions are available for the subjects
 #
 # Usage:
 # sct_run_batch -jobs 1 -path-data bids_dataset -path-out res_registration -script pipeline_bids_register_evaluate.sh
@@ -47,6 +49,23 @@ sct_check_dependencies -short
 SUBJECT_ID=$(dirname "$SUBJECT")
 SES=$(basename "$SUBJECT")
 
+# PARAMETERS TO SPECIFY
+# ==============================================================================
+# Choose the registration model to use (should be in the model folder)
+REGISTRATION_MODEL="registration_model.h5"
+# Choose the config file to use (should be in the config folder)
+INFERENCE_CONFIG='config_inference.json'
+# Choose the name and the extension of the fixed volume (ex: T1w and .nii.gz) and its contrast (ex: t1)
+FX_NAME="T1w"
+FX_EXT=".nii.gz"
+FX_CONTRAST="t1"
+# Choose the name and the extension of the moving volume (ex: T2w and .nii.gz) and its contrast (ex: t2)
+MOV_NAME="T2w"
+MOV_EXT=".nii.gz"
+MOV_CONTRAST="t2"
+# Specify if multi-sessions are available per subject: if yes set the value to 1, if no set the value to 0
+MULT_SESSIONS=0
+
 # Choose whether to keep all the files created during the process (DEBUGGING=1) (in add_res and seg folders) to debug
 # and observe what happened at the different steps of the process or to keep only the two volumes of origin
 # and processed/registered (in origin and res folders) (DEBUGGING=0)
@@ -55,10 +74,7 @@ DEBUGGING=1
 # will later be used for other tasks, such as segmentation. If the value is 1, the res folder will be removed and the
 # registered volumes will be directly present in the anat folder and with the same names as the original volumes
 KEEP_ORI_NAMING_LOC=0
-# Choose the registration model to use (should be in the model folder)
-REGISTRATION_MODEL="registration_model.h5"
-# Choose the config file to use (should be in the config folder)
-INFERENCE_CONFIG='config_inference.json'
+# ==============================================================================
 
 # Go to folder where data will be copied and processed
 cd ${PATH_DATA_PROCESSED}
@@ -69,55 +85,87 @@ rsync -avzh $PATH_DATA/$SUBJECT/ ${SUBJECT}
 echo $PWD
 cd ${SUBJECT}/anat/
 
-file_t1_before_proc="${SES}_T1w.nii.gz"
-file_t2_before_proc="${SES}_T2w.nii.gz"
+if [ $MULT_SESSIONS == 1 ]
+then
+  file_fx_before_proc="${SUBJECT_ID}_${SES}_${FX_NAME}${FX_EXT}"
+  file_mov_before_proc="${SUBJECT_ID}_${SES}_${MOV_NAME}${MOV_EXT}"
+else
+  file_fx_before_proc="${SES}_${FX_NAME}${FX_EXT}"
+  file_mov_before_proc="${SES}_${MOV_NAME}${MOV_EXT}"
+fi
 
 CONDA_BASE=$(conda info --base)
 source $CONDA_BASE/etc/profile.d/conda.sh
 conda activate smenv
 # Perform processing and registration
-python $PATH_SCRIPT/bids_registration.py --model-path $PATH_SCRIPT/model/$REGISTRATION_MODEL --config-path $PATH_SCRIPT/config/$INFERENCE_CONFIG --fx-img-path $file_t1_before_proc --mov-img-path $file_t2_before_proc --fx-img-contrast T1w --one-cpu-tf False
+python $PATH_SCRIPT/bids_registration.py --model-path $PATH_SCRIPT/model/$REGISTRATION_MODEL --config-path $PATH_SCRIPT/config/$INFERENCE_CONFIG --fx-img-path $file_fx_before_proc --mov-img-path $file_mov_before_proc --fx-img-contrast $FX_NAME --one-cpu-tf False
 conda deactivate
 
-file_t1="${SES}_T1w_proc"
-file_t2="${SES}_T2w_proc"
-file_t2_reg="${SES}_T2w_proc_reg_to_T1w"
+if [ $MULT_SESSIONS == 1 ]
+then
+  file_fx="${SUBJECT_ID}_${SES}_${FX_NAME}_proc"
+  file_mov="${SUBJECT_ID}_${SES}_${MOV_NAME}_proc"
+  file_mov_reg="${SUBJECT_ID}_${SES}_${MOV_NAME}_proc_reg_to_${FX_NAME}"
+else
+  file_fx="${SES}_${FX_NAME}_proc"
+  file_mov="${SES}_${MOV_NAME}_proc"
+  file_mov_reg="${SES}_${MOV_NAME}_proc_reg_to_${FX_NAME}"
+fi
 
 # Segment spinal cord
-segment $file_t1 "t1"
-segment $file_t2 "t2"
-segment $file_t2_reg "t2"
+segment $file_fx $FX_CONTRAST
+segment $file_mov $MOV_CONTRAST
+segment $file_mov_reg $MOV_CONTRAST
 
-file_t1_seg="${SES}_T1w_proc_seg"
-file_t2_seg="${SES}_T2w_proc_seg"
-file_t2_reg_seg="${SES}_T2w_proc_reg_to_T1w_seg"
+if [ $MULT_SESSIONS == 1 ]
+then
+  file_fx_seg="${SUBJECT_ID}_${SES}_${FX_NAME}_proc_seg"
+  file_mov_seg="${SUBJECT_ID}_${SES}_${MOV_NAME}_proc_seg"
+  file_mov_reg_seg="${SUBJECT_ID}_${SES}_${MOV_NAME}_proc_reg_to_${FX_NAME}_seg"
+  sub_id="${SUBJECT_ID}_${SES}"
+else
+  file_fx_seg="${SES}_${FX_NAME}_proc_seg"
+  file_mov_seg="${SES}_${MOV_NAME}_proc_seg"
+  file_mov_reg_seg="${SES}_${MOV_NAME}_proc_reg_to_${FX_NAME}_seg"
+  sub_id="${SES}"
+fi
 
 conda activate smenv
 # Compute Dice score of SC segmentation overlap before and after registration and save the results in a csv file
-python $PATH_SCRIPT/eval_reg_on_sc_seg.py --fx-seg-path $file_t1_seg --moving-seg-path $file_t2_seg --warped-seg-path $file_t2_reg_seg --sub-id ${SES} --out-file $PATH_DATA_PROCESSED/metrics_on_sc_seg.csv --append 1
+python $PATH_SCRIPT/eval_reg_on_sc_seg.py --fx-seg-path $file_fx_seg --moving-seg-path $file_mov_seg --warped-seg-path $file_mov_reg_seg --sub-id $sub_id --out-file $PATH_DATA_PROCESSED/metrics_on_sc_seg.csv --append 1
 # Compute the normalized Mutual Information and save the results in a csv file
-python $PATH_SCRIPT/eval_reg_with_mi.py --fx-im-path $file_t1_seg --moving-im-path $file_t2_seg --warped-im-path $file_t2_reg_seg --sub-id ${SES} --out-file $PATH_DATA_PROCESSED/nmi.csv --append 1
+python $PATH_SCRIPT/eval_reg_with_mi.py --fx-im-path $file_fx_seg --moving-im-path $file_mov_seg --warped-im-path $file_mov_reg_seg --sub-id $sub_id --out-file $PATH_DATA_PROCESSED/nmi.csv --append 1
 conda deactivate
 
 # Generate QC report to assess registration
-sct_qc -i ${file_t1}.nii.gz -s ${file_t1_seg}.nii.gz -d ${file_t2}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
-sct_qc -i ${file_t1}.nii.gz -s ${file_t1_seg}.nii.gz -d ${file_t2_reg}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
-sct_qc -i ${file_t2}.nii.gz -s ${file_t2_seg}.nii.gz -d ${file_t2_reg}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
+sct_qc -i ${file_fx}.nii.gz -s ${file_fx_seg}.nii.gz -d ${file_mov}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
+sct_qc -i ${file_fx}.nii.gz -s ${file_fx_seg}.nii.gz -d ${file_mov_reg}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
+sct_qc -i ${file_mov}.nii.gz -s ${file_fx_seg}.nii.gz -d ${file_mov_reg}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
 
 # Rearrange the different files to obtain an output that has a better structure and is easier to use
-# The processed T1w and processed + registered T2w volumes are stored in the res folder or directly in anat folder if KEEP_ORI_NAMING_LOC=1
-# The original T1w and T2w volumes are stored in the origin folder
+# The processed fixed and processed + registered moving volumes are stored in the res folder or directly in anat folder if KEEP_ORI_NAMING_LOC=1
+# The original fixed and moving volumes are stored in the origin folder
 # If DEBUGGING=1, the additional volumes computed during the process are stored in the add_res folder
 # and the segmentations are stored in the seg folder
 mkdir origin
-mv "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T1w.nii.gz" "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/origin/${SES}_T1w.nii.gz"
-mv "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T2w.nii.gz" "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/origin/${SES}_T2w.nii.gz"
-mv "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T1w.json" "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/origin/${SES}_T1w.json"
-mv "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T2w.json" "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/origin/${SES}_T2w.json"
+mv "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${file_fx_before_proc}" "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/origin/${file_fx_before_proc}"
+mv "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${file_mov_before_proc}" "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/origin/${file_mov_before_proc}"
+
+if [ $MULT_SESSIONS == 1 ]
+then
+  json_fx_ori="${SUBJECT_ID}_${SES}_${FX_NAME}.json"
+  json_mov_ori="${SUBJECT_ID}_${SES}_${MOV_NAME}.json"
+else
+  json_fx_ori="${SES}_${FX_NAME}.json"
+  json_mov_ori="${SES}_${MOV_NAME}.json"
+fi
+
+mv "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${json_fx_ori}" "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/origin/${json_fx_ori}"
+mv "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${json_mov_ori}" "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/origin/${json_mov_ori}"
 
 mkdir res
-mv "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T1w_proc.nii.gz" "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${SES}_T1w_proc.nii.gz"
-mv "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T2w_proc_reg_to_T1w.nii.gz" "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${SES}_T2w_proc_reg_to_T1w.nii.gz"
+mv "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${file_fx}.nii.gz" "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${file_fx}.nii.gz"
+mv "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${file_mov_reg}.nii.gz" "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${file_mov_reg}.nii.gz"
 
 if [ $DEBUGGING == 1 ]
 then
@@ -143,8 +191,8 @@ fi
 
 if [ $KEEP_ORI_NAMING_LOC == 1 ]
 then
-  mv "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${SES}_T1w_proc.nii.gz" "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T1w.nii.gz"
-  mv "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${SES}_T2w_proc_reg_to_T1w.nii.gz" "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T2w.nii.gz"
+  mv "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${file_fx}.nii.gz" "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${file_fx_before_proc}"
+  mv "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${file_mov_reg}.nii.gz" "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${file_mov_before_proc}"
   rm -rf "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/"
 fi
 
@@ -153,13 +201,13 @@ fi
 if [ $KEEP_ORI_NAMING_LOC == 0 ]
 then
   FILES_TO_CHECK=(
-    "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${SES}_T1w_proc.nii.gz"
-    "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${SES}_T2w_proc_reg_to_T1w.nii.gz"
+    "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${file_fx}.nii.gz"
+    "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/res/${file_mov_reg}.nii.gz"
   )
 else
   FILES_TO_CHECK=(
-    "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T1w.nii.gz"
-    "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${SES}_T2w.nii.gz"
+    "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${file_fx}.nii.gz"
+    "${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${file_mov_reg}.nii.gz"
   )
 fi
 


### PR DESCRIPTION
Generalize the framework for registration and evaluation to register any type of contrasts together.

The user needs to specify which modality (contrast) is used as the fixed image and which modality (contrast) will be registered to this fixed image (the moving image). In addition, the user should specify if data from multiple sessions are available.

Once this is done, the process will be fully automatic to register the moving image of the specified modality to the fixed image for each subject (and each session) of the dataset (organised following BIDS convention).