### PR TITLE
Separate QC files for SC seg and SC reg

### DIFF
--- a/pipeline_bids_register_evaluate.sh
+++ b/pipeline_bids_register_evaluate.sh
@@ -34,11 +34,10 @@ start=`date +%s`
 segment(){
   local file="$1"
   local contrast="$2"
-  folder_contrast="anat"
 
   echo "Proceeding with automatic segmentation"
   # Segment spinal cord
-  sct_deepseg_sc -i ${file}.nii.gz -c $contrast -qc ${PATH_QC} -qc-subject ${SUBJECT}
+  sct_deepseg_sc -i ${file}.nii.gz -c $contrast -qc ${PATH_QC}_seg -qc-subject ${SUBJECT}
 }
 
 # SCRIPT STARTS HERE
@@ -160,9 +159,8 @@ conda deactivate
 if [ $EVAL_METRICS_ON_SC_SEG == 1 ]
 then
   # Generate QC report to assess registration
-  sct_qc -i ${file_fx}.nii.gz -s ${file_fx_seg}.nii.gz -d ${file_mov}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
-  sct_qc -i ${file_fx}.nii.gz -s ${file_fx_seg}.nii.gz -d ${file_mov_reg}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
-  sct_qc -i ${file_mov}.nii.gz -s ${file_fx_seg}.nii.gz -d ${file_mov_reg}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
+  sct_qc -i ${file_fx}.nii.gz -s ${file_fx_seg}.nii.gz -d ${file_mov}.nii.gz -p sct_register_multimodal -qc ${PATH_QC}_reg -qc-subject ${SUBJECT}
+  sct_qc -i ${file_fx}.nii.gz -s ${file_fx_seg}.nii.gz -d ${file_mov_reg}.nii.gz -p sct_register_multimodal -qc ${PATH_QC}_reg -qc-subject ${SUBJECT}
 fi
 
 # Rearrange the different files to obtain an output that has a better structure and is easier to use

--- a/pipeline_bids_register_evaluate_opt_affine.sh
+++ b/pipeline_bids_register_evaluate_opt_affine.sh
@@ -37,11 +37,10 @@ start=`date +%s`
 segment(){
   local file="$1"
   local contrast="$2"
-  folder_contrast="anat"
 
   echo "Proceeding with automatic segmentation"
   # Segment spinal cord
-  sct_deepseg_sc -i ${file}.nii.gz -c $contrast -qc ${PATH_QC} -qc-subject ${SUBJECT}
+  sct_deepseg_sc -i ${file}.nii.gz -c $contrast -qc ${PATH_QC}_seg -qc-subject ${SUBJECT}
 }
 
 # SCRIPT STARTS HERE
@@ -244,9 +243,8 @@ else
 fi
 
 # Generate QC report to assess registration
-sct_qc -i ${file_fx}.nii.gz -s ${file_fx_seg}.nii.gz -d ${file_mov}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
-sct_qc -i ${file_fx}.nii.gz -s ${file_fx_seg}.nii.gz -d ${file_mov_reg}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
-sct_qc -i ${file_mov}.nii.gz -s ${file_fx_seg}.nii.gz -d ${file_mov_reg}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
+sct_qc -i ${file_fx}.nii.gz -s ${file_fx_seg}.nii.gz -d ${file_mov}.nii.gz -p sct_register_multimodal -qc ${PATH_QC}_reg -qc-subject ${SUBJECT}
+sct_qc -i ${file_fx}.nii.gz -s ${file_fx_seg}.nii.gz -d ${file_mov_reg}.nii.gz -p sct_register_multimodal -qc ${PATH_QC}_reg -qc-subject ${SUBJECT}
 
 # Rearrange the different files to obtain an output that has a better structure and is easier to use
 # The processed fixed and processed + registered moving volumes are stored in the res folder or directly in anat folder if KEEP_ORI_NAMING_LOC=1

--- a/pipeline_bids_register_evaluate_two_steps.sh
+++ b/pipeline_bids_register_evaluate_two_steps.sh
@@ -36,11 +36,10 @@ start=`date +%s`
 segment(){
   local file="$1"
   local contrast="$2"
-  folder_contrast="anat"
 
   echo "Proceeding with automatic segmentation"
   # Segment spinal cord
-  sct_deepseg_sc -i ${file}.nii.gz -c $contrast -qc ${PATH_QC} -qc-subject ${SUBJECT}
+  sct_deepseg_sc -i ${file}.nii.gz -c $contrast -qc ${PATH_QC}_seg -qc-subject ${SUBJECT}
 }
 
 # SCRIPT STARTS HERE
@@ -169,9 +168,8 @@ conda deactivate
 if [ $EVAL_METRICS_ON_SC_SEG == 1 ]
 then
   # Generate QC report to assess registration
-  sct_qc -i ${file_fx}.nii.gz -s ${file_fx_seg}.nii.gz -d ${file_mov}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
-  sct_qc -i ${file_fx}.nii.gz -s ${file_fx_seg}.nii.gz -d ${file_mov_reg}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
-  sct_qc -i ${file_mov}.nii.gz -s ${file_fx_seg}.nii.gz -d ${file_mov_reg}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
+  sct_qc -i ${file_fx}.nii.gz -s ${file_fx_seg}.nii.gz -d ${file_mov}.nii.gz -p sct_register_multimodal -qc ${PATH_QC}_reg -qc-subject ${SUBJECT}
+  sct_qc -i ${file_fx}.nii.gz -s ${file_fx_seg}.nii.gz -d ${file_mov_reg}.nii.gz -p sct_register_multimodal -qc ${PATH_QC}_reg -qc-subject ${SUBJECT}
 fi
 
 # Rearrange the different files to obtain an output that has a better structure and is easier to use


### PR DESCRIPTION
Create one folder for the QC file that allows to observe if the segmentation of the SC went well (to compute relevant metrics like Dice score, Jaccard, ...) and one folder to assess the SC registration.

In addition, remove a useless comparison between the moving image and the moved one as this can be done by going up and down in the QC report.